### PR TITLE
fix: upgrade to Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21-alpine3.19
+FROM node:22.5.1-alpine3.19@sha256:17e6738cb7ac3d65860d51533372dad098c00d15bdfdb0b5f3897824eb9e11a5
 ENV NODE_ENV=production
 
 # Create and change to the app directory.
@@ -14,4 +14,4 @@ COPY . .
 
 EXPOSE 3001
 
-ENTRYPOINT [ "yarn", "start"]
+ENTRYPOINT ["yarn", "start"]


### PR DESCRIPTION
# Summary
Upgrade the API Docker image to use Node 22.5.1 and pin to the image SHA.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946