### PR TITLE
chore: rename ECS API task from form-api to forms-api

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -11,7 +11,7 @@ env:
   AWS_ACCOUNT_ID: ${{ vars.STAGING_AWS_ACCOUNT_ID }}
   AWS_REGION: ca-central-1
   CLUSTER_NAME: Forms
-  SERVICE_NAME: form-api
+  SERVICE_NAME: forms-api
   REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/forms/api
 
 permissions:
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy-form-api-service:
+  deploy-forms-api-service:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Summary | Résumé

Linked to https://github.com/cds-snc/forms-terraform/pull/766

- Renames ECS Task name from `form-api` to `forms-api`