### PR TITLE
fix: deploy latest task definition

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -47,13 +47,18 @@ jobs:
           container-name: ${{ env.SERVICE_NAME }}
           image: "${{ env.REGISTRY }}:${{ github.sha }}"
 
-      - name: Deploy updated ECS task
+      - name: Create the new ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@0a9a8fb7b39516cf53cc01d453b05c67c6fc7a2c # v2.0.0
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: ${{ env.SERVICE_NAME }}
           cluster: ${{ env.CLUSTER_NAME }}
-          wait-for-service-stability: true
+
+      - name: Deploy the new ECS task definition
+        run: |
+          aws ecs update-service \
+            --cluster ${{ env.CLUSTER_NAME }} \
+            --service ${{ env.SERVICE_NAME }} \
+            --force-new-deployment
 
       - name: Report deployment to Sentinel
         if: always()


### PR DESCRIPTION
# Summary
Update the workflow to trigger a new deploy of the latest ACTIVE task definition using the AWS CLI.

This is being done so that the ECS service's task definition attribute remains in sync with the Terraform.

The behaviour of the ECS service has been updated to always deploy the latest ACTIVE task definition, thereby giving precedence to the deployment workflows in this repo.

# Related
- https://github.com/cds-snc/forms-terraform/pull/767
- https://github.com/cds-snc/platform-forms-client/issues/4128
- https://github.com/cds-snc/terraform-modules/pull/544