### PR TITLE
fix: deploy latest ECS task definition

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -12,6 +12,7 @@ env:
   AWS_REGION: ca-central-1
   CLUSTER_NAME: Forms
   SERVICE_NAME: forms-api
+  TASK_DEFINITION_NAME: forms-api
   REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/forms/api
 
 permissions:
@@ -58,7 +59,8 @@ jobs:
           aws ecs update-service \
             --cluster ${{ env.CLUSTER_NAME }} \
             --service ${{ env.SERVICE_NAME }} \
-            --force-new-deployment
+            --task-definition ${{ env.TASK_DEFINITION_NAME }} \
+            --force-new-deployment > /dev/null 2>&1
 
       - name: Report deployment to Sentinel
         if: always()


### PR DESCRIPTION
# Summary
Update the Staging deploy workflow to include the task definition name.  This causes the ECS service to correctly use the latest ACTIVE task definition.

Also hides the command output to prevent accidental disclosure of information.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946