### PR TITLE
feat: wait for service deployment stability

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -61,6 +61,9 @@ jobs:
             --service ${{ env.SERVICE_NAME }} \
             --task-definition ${{ env.TASK_DEFINITION_NAME }} \
             --force-new-deployment > /dev/null 2>&1
+          aws ecs wait services-stable \
+            --cluster ${{ env.CLUSTER_NAME }} \
+            --services ${{ env.SERVICE_NAME }}
 
       - name: Report deployment to Sentinel
         if: always()


### PR DESCRIPTION
# Summary
Update the Staging deployment workflow to wait until the `forms-api` service is stable.  This will cause the workflow to fail if the service cannot be deployed and run as expected.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/3946