### PR TITLE
feat: devcontainer DynamoDB and Redis services

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Forms API",
-  "image": "mcr.microsoft.com/vscode/devcontainers/base:debian@sha256:f1ac6335fc8cdd253c673a76edf77d81b5aa4bf9746bc67ecce4337d6bbaeb20",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspace/forms-api",
   "containerEnv": {
     "SHELL": "/bin/zsh"
   },
@@ -17,7 +19,6 @@
       "extensions": ["github.copilot", "github.vscode-github-actions"]
     }
   },
-  "appPort": [3001],
-  "postCreateCommand": "corepack enable pnpm && corepack use pnpm@9.6.0 && pnpm install",
+  "postCreateCommand": "./.devcontainer/post-create.sh",
   "remoteUser": "vscode"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  devcontainer:
+    image: mcr.microsoft.com/vscode/devcontainers/base:debian@sha256:f1ac6335fc8cdd253c673a76edf77d81b5aa4bf9746bc67ecce4337d6bbaeb20
+    command: sleep infinity
+    depends_on:
+      - dynamodb
+      - redis
+    ports:
+      - 3001:3001
+    volumes:
+      - ..:/workspace/forms-api:cached
+    environment:
+      AWS_REGION: ca-central-1
+      AWS_ACCESS_KEY_ID: AWSACCESSKEYID
+      AWS_SECRET_ACCESS_KEY: AWSSECRETACCESSKEY
+
+  dynamodb:
+    image: amazon/dynamodb-local:latest@sha256:d7ebddeb60fa418bcda218a6c6a402a58441b2a20d54c9cb1d85fd5194341753
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    restart: unless-stopped
+    user: root
+    ports:
+      - 8000:8000
+    volumes:
+      - dynamodb_data:/home/dynamodblocal/data
+    working_dir: /home/dynamodblocal
+
+  redis:
+    image: redis:6.2@sha256:da122fff8a838685f3b4e25b3f797ad0c71a6425648e8f944cad8ee56a4e3b16
+    restart: unless-stopped
+    ports:
+      - 6379:6379
+    volumes:
+        - redis_data:/data
+
+volumes:
+  dynamodb_data:
+  redis_data:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+corepack enable pnpm
+corepack use pnpm@9.6.0
+
+pnpm config set store-dir /home/vscode/pnpm/store
+pnpm install

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-corepack enable pnpm
-corepack use pnpm@9.6.0
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0 
 
+corepack enable pnpm
 pnpm config set store-dir /home/vscode/pnpm/store
+
+corepack use pnpm@9.6.0
 pnpm install

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 npm-debug.log
 .DS_Store
 *.gz
+*_private_api_key.json
 .env
 build/
 .pnpm-store


### PR DESCRIPTION
# Summary
Update the devcontainer so that it includes a local Redis and DynamoDB service.  This is being done for cases where a LocalStack Pro license is not available.

# Related
- https://github.com/cds-snc/platform-forms-client/issues/4215