### PR TITLE
feat: add token authentication cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # Required when running the API locally so that it communicates with your Localstack instance
 LOCALSTACK_ENDPOINT=http://127.0.0.1:4566
 
+# Redis
+REDIS_URL=redis://redis:6379
+
 # Zitadel
 PROJECT_ID=123 # This is the GCForms project ID in Zitadel
 ZITADEL_DOMAIN=https://auth.forms-staging.cdssandbox.xyz

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "axios": "^1.7.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "jose": "^5.6.3"
+    "jose": "^5.6.3",
+    "redis": "^4.7.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       jose:
         specifier: ^5.6.3
         version: 5.6.3
+      redis:
+        specifier: ^4.7.0
+        version: 4.7.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.8.3
@@ -427,6 +430,35 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.0':
+    resolution: {integrity: sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
 
   '@rollup/rollup-android-arm-eabi@4.20.0':
     resolution: {integrity: sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==}
@@ -842,6 +874,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1021,6 +1057,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -1328,6 +1368,9 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redis@4.7.0:
+    resolution: {integrity: sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1602,6 +1645,9 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
 snapshots:
 
@@ -2152,6 +2198,32 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@redis/bloom@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/client@1.6.0':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/json@1.0.7(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/search@1.2.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.0)':
+    dependencies:
+      '@redis/client': 1.6.0
+
   '@rollup/rollup-android-arm-eabi@4.20.0':
     optional: true
 
@@ -2698,6 +2770,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  cluster-key-slot@1.1.2: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -2911,6 +2985,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  generic-pool@3.9.0: {}
 
   get-func-name@2.0.2: {}
 
@@ -3170,6 +3246,15 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redis@4.7.0:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.0)
+      '@redis/client': 1.6.0
+      '@redis/graph': 1.1.1(@redis/client@1.6.0)
+      '@redis/json': 1.0.7(@redis/client@1.6.0)
+      '@redis/search': 1.2.0(@redis/client@1.6.0)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.0)
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -3458,3 +3543,5 @@ snapshots:
       stackback: 0.0.2
 
   wrappy@1.0.2: {}
+
+  yallist@4.0.0: {}

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,10 @@ export const LOCALSTACK_ENDPOINT: string | undefined = loadOptionalEnvVar(
   "LOCALSTACK_ENDPOINT",
 );
 
+// Redis
+
+export const REDIS_URL: string = loadRequiredEnvVar("REDIS_URL");
+
 // Zitadel
 
 export const ZITADEL_APPLICATION_KEY: string = loadRequiredEnvVar(

--- a/src/lib/idp/introspectToken.ts
+++ b/src/lib/idp/introspectToken.ts
@@ -4,7 +4,7 @@ import axios, { type AxiosError } from "axios";
 import { createPrivateKey } from "node:crypto";
 import { ZITADEL_APPLICATION_KEY, ZITADEL_DOMAIN } from "@src/config";
 
-type IntrospectionResult = {
+export type IntrospectionResult = {
   username: string;
   exp: number;
 };

--- a/src/lib/idp/introspectionCache.ts
+++ b/src/lib/idp/introspectionCache.ts
@@ -5,7 +5,7 @@ import { RedisConnector } from "@src/lib/redisConnector";
 
 const cacheExpiry = 300; // seconds
 
-export function getAccessTokenCacheKey(accessToken: string): string {
+function getAccessTokenCacheKey(accessToken: string): string {
   const hash = createHash("sha256").update(accessToken).digest("base64");
   return `api:auth:${hash}`;
 }

--- a/src/lib/idp/introspectionCache.ts
+++ b/src/lib/idp/introspectionCache.ts
@@ -1,0 +1,36 @@
+// biome-ignore lint/correctness/noNodejsModules: we need the node crypto module
+import { createHash } from "node:crypto";
+import type { IntrospectionResult } from "@lib/idp/introspectToken";
+import { RedisConnector } from "@src/lib/redisConnector";
+
+const cacheExpiry = 300; // seconds
+
+export function getAccessTokenCacheKey(accessToken: string): string {
+  const hash = createHash("sha256").update(accessToken).digest("base64");
+  return `api:auth:${hash}`;
+}
+
+export async function getIntrospectionCache(
+  accessToken: string,
+): Promise<IntrospectionResult | undefined> {
+  const accessTokenKey = getAccessTokenCacheKey(accessToken);
+  const redisConnector = await RedisConnector.getInstance();
+  const introspectionCached = await redisConnector.client.get(accessTokenKey);
+  console.debug("Introspection cache", accessTokenKey, introspectionCached);
+  return introspectionCached
+    ? (JSON.parse(introspectionCached) as IntrospectionResult)
+    : undefined;
+}
+
+export async function setIntrospectionCache(
+  accessToken: string,
+  introspectionResult: IntrospectionResult,
+): Promise<void> {
+  const accessTokenKey = getAccessTokenCacheKey(accessToken);
+  const redisConnector = await RedisConnector.getInstance();
+  await redisConnector.client.set(
+    accessTokenKey,
+    JSON.stringify(introspectionResult),
+    { EX: cacheExpiry },
+  );
+}

--- a/src/lib/redisConnector.ts
+++ b/src/lib/redisConnector.ts
@@ -31,11 +31,10 @@ export class RedisConnector {
    * instance is first initialized, even if multiple concurrent calls are made.
    * @returns {Promise<RedisConnector>}
    */
-  // biome-ignore lint/suspicious/useAwait: Singleton Promise is resolved by the caller
   public static async getInstance(): Promise<RedisConnector> {
     if (RedisConnector.instance === undefined) {
       RedisConnector.instance = new RedisConnector();
-      RedisConnector.instance.client.connect();
+      await RedisConnector.instance.client.connect();
     }
     return RedisConnector.instance;
   }

--- a/src/lib/redisConnector.ts
+++ b/src/lib/redisConnector.ts
@@ -24,6 +24,7 @@ export class RedisConnector {
       .on("reconnecting", () => console.debug("Redis client reconnecting..."));
   }
 
+  // biome-ignore lint/suspicious/useAwait: Singleton Promise is resolved by the caller
   public static async getInstance(): Promise<RedisConnector> {
     if (RedisConnector.instance === undefined) {
       RedisConnector.instance = new RedisConnector();

--- a/src/lib/redisConnector.ts
+++ b/src/lib/redisConnector.ts
@@ -3,23 +3,31 @@ import { REDIS_URL } from "@src/config";
 
 export class RedisConnector {
   private static instance: RedisConnector | undefined = undefined;
+  private static RETRY_MAX = 5;
+  private static RETRY_DELAY = 1000;
 
   public client: RedisClientType;
 
   private constructor() {
-    this.client = createClient({ url: REDIS_URL });
+    this.client = createClient({
+      url: REDIS_URL,
+      socket: {
+        reconnectStrategy: (retries: number): number | Error =>
+          retries < RedisConnector.RETRY_MAX
+            ? RedisConnector.RETRY_DELAY
+            : new Error("Failed to connect to Redis"),
+      },
+    });
     this.client
-      .on("error", (err) => console.error("Redis client error:", err))
-      .on("reconnecting", () => console.info("Redis client reconnecting..."));
+      .on("error", (err: Error) => console.error("Redis client error:", err))
+      .on("ready", () => console.debug("Redis client ready!"))
+      .on("reconnecting", () => console.debug("Redis client reconnecting..."));
   }
 
   public static async getInstance(): Promise<RedisConnector> {
-    if (
-      RedisConnector.instance === undefined ||
-      !RedisConnector.instance.client.isReady
-    ) {
+    if (RedisConnector.instance === undefined) {
       RedisConnector.instance = new RedisConnector();
-      await RedisConnector.instance.client.connect();
+      RedisConnector.instance.client.connect();
     }
     return RedisConnector.instance;
   }

--- a/src/lib/redisConnector.ts
+++ b/src/lib/redisConnector.ts
@@ -1,0 +1,26 @@
+import { type RedisClientType, createClient } from "redis";
+import { REDIS_URL } from "@src/config";
+
+export class RedisConnector {
+  private static instance: RedisConnector | undefined = undefined;
+
+  public client: RedisClientType;
+
+  private constructor() {
+    this.client = createClient({ url: REDIS_URL });
+    this.client
+      .on("error", (err) => console.error("Redis client error:", err))
+      .on("reconnecting", () => console.info("Redis client reconnecting..."));
+  }
+
+  public static async getInstance(): Promise<RedisConnector> {
+    if (
+      RedisConnector.instance === undefined ||
+      !RedisConnector.instance.client.isReady
+    ) {
+      RedisConnector.instance = new RedisConnector();
+      await RedisConnector.instance.client.connect();
+    }
+    return RedisConnector.instance;
+  }
+}

--- a/src/middleware/authentication/middleware.ts
+++ b/src/middleware/authentication/middleware.ts
@@ -4,10 +4,10 @@ import type { NextFunction, Request, Response } from "express";
 import { introspectToken } from "@lib/idp/introspectToken";
 import { RedisConnector } from "@src/lib/redisConnector";
 
-const cacheExpiry = 60; // seconds
+const cacheExpiry = 300; // seconds
 
 export function getAccessTokenCacheKey(accessToken: string): string {
-  const hash = createHash("sha256").update(accessToken).digest("hex");
+  const hash = createHash("sha256").update(accessToken).digest("base64");
   return `api:auth:${hash}`;
 }
 

--- a/src/middleware/authentication/middleware.ts
+++ b/src/middleware/authentication/middleware.ts
@@ -1,4 +1,5 @@
-import { createHash } from "crypto";
+// biome-ignore lint/correctness/noNodejsModules: we need the node crypto module
+import { createHash } from "node:crypto";
 import type { NextFunction, Request, Response } from "express";
 import { introspectToken } from "@lib/idp/introspectToken";
 import { RedisConnector } from "@src/lib/redisConnector";

--- a/src/middleware/authentication/middleware.ts
+++ b/src/middleware/authentication/middleware.ts
@@ -26,7 +26,7 @@ export async function authenticationMiddleware(
   // This is being done to reduce strain on the IdP.
   const accessTokenKey = getAccessTokenCacheKey(accessToken);
   const introspectionCached = await redisConnector.client.get(accessTokenKey);
-  console.debug("Introspection cache result", accessTokenKey, introspectionCached);
+  console.debug("Introspection cache", accessTokenKey, introspectionCached);
 
   const introspectionResult = introspectionCached
     ? JSON.parse(introspectionCached)

--- a/src/middleware/authentication/middleware.ts
+++ b/src/middleware/authentication/middleware.ts
@@ -1,5 +1,14 @@
+import { createHash } from "crypto";
 import type { NextFunction, Request, Response } from "express";
 import { introspectToken } from "@lib/idp/introspectToken";
+import { RedisConnector } from "@src/lib/redisConnector";
+
+const cacheExpiry = 60; // seconds
+
+export function getAccessTokenCacheKey(accessToken: string): string {
+  const hash = createHash("sha256").update(accessToken).digest("hex");
+  return `api:auth:${hash}`;
+}
 
 export async function authenticationMiddleware(
   request: Request,
@@ -7,12 +16,21 @@ export async function authenticationMiddleware(
   next: NextFunction,
 ) {
   const accessToken = request.headers.authorization?.split(" ")[1];
+  const redisConnector = await RedisConnector.getInstance();
 
   if (!accessToken) {
     return response.sendStatus(401);
   }
 
-  const introspectionResult = await introspectToken(accessToken);
+  // Check if there is a cached introspection result for this token.
+  // This is being done to reduce strain on the IdP.
+  const accessTokenKey = getAccessTokenCacheKey(accessToken);
+  const introspectionCached = await redisConnector.client.get(accessTokenKey);
+  console.debug("Introspection cache result", accessTokenKey, introspectionCached);
+
+  const introspectionResult = introspectionCached
+    ? JSON.parse(introspectionCached)
+    : await introspectToken(accessToken);
 
   if (!introspectionResult) {
     return response.sendStatus(403);
@@ -27,6 +45,13 @@ export async function authenticationMiddleware(
   if (introspectionResult.exp < Date.now() / 1000) {
     return response.status(401).json({ message: "Token expired" });
   }
+
+  // Store the introspection result in the cache
+  await redisConnector.client.set(
+    accessTokenKey,
+    JSON.stringify(introspectionResult),
+    { EX: cacheExpiry },
+  );
 
   next();
 }

--- a/test/lib/idp/introspectionCache.test.ts
+++ b/test/lib/idp/introspectionCache.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RedisConnector } from "@src/lib/redisConnector";
+import {
+  getIntrospectionCache,
+  setIntrospectionCache,
+} from "@src/lib/idp/introspectionCache";
+import type { IntrospectionResult } from "@lib/idp/introspectToken";
+
+vi.mock("@src/lib/redisConnector");
+const redisConnectorMock = vi.mocked(RedisConnector);
+
+describe("introspectionCache", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: we need to assign the Redis client and allow mock resolved values
+  const redisClient: any = {
+    get: vi.fn(),
+    set: vi.fn(),
+  };
+  const authTokenCacheKey =
+    "api:auth:RkS8hzu0MtwL+Qs2lK7KX9CLK7v6lxYpqs7ns5MwuOs=";
+
+  beforeEach(() => {
+    redisConnectorMock.getInstance.mockResolvedValue({ client: redisClient });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getIntrospectionCache should", () => {
+    it("return the parsed introspection result if the cache is found", async () => {
+      const accessToken = "testAccessToken";
+      const introspectionResult: IntrospectionResult = {
+        username: "Frodo",
+        exp: 1234567890,
+      };
+      redisClient.get.mockResolvedValue(JSON.stringify(introspectionResult));
+
+      const result = await getIntrospectionCache(accessToken);
+      expect(result).toEqual(introspectionResult);
+      expect(redisClient.get).toHaveBeenCalledWith(authTokenCacheKey);
+    });
+
+    it("return undefined if the cache is not found", async () => {
+      const accessToken = "testAccessToken";
+      redisClient.get.mockResolvedValue(null);
+
+      const result = await getIntrospectionCache(accessToken);
+      expect(result).toBeUndefined();
+      expect(redisClient.get).toHaveBeenCalledWith(authTokenCacheKey);
+    });
+  });
+
+  describe("setIntrospectionCache should", () => {
+    it("set the cache correctly in Redis", async () => {
+      const accessToken = "testAccessToken";
+      const introspectionResult: IntrospectionResult = {
+        username: "Frodo",
+        exp: 1234567890,
+      };
+
+      await setIntrospectionCache(accessToken, introspectionResult);
+      expect(redisClient.set).toHaveBeenCalledWith(
+        authTokenCacheKey,
+        JSON.stringify(introspectionResult),
+        { EX: 300 },
+      );
+    });
+  });
+});

--- a/test/lib/redisConnector.test.ts
+++ b/test/lib/redisConnector.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { type RedisClientType, createClient } from "redis";
+import { RedisConnector } from "@src/lib/redisConnector";
+
+vi.mock("redis", () => {
+  const client = {
+    connect: vi.fn(),
+    quit: vi.fn(),
+    on: vi.fn().mockReturnThis(),
+  };
+  return {
+    createClient: vi.fn(() => client),
+  };
+});
+
+describe("RedisConnector should", () => {
+  let redisClientMock: RedisClientType;
+
+  beforeEach(() => {
+    redisClientMock = createClient();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("create a Redis client instance", async () => {
+    const instance = await RedisConnector.getInstance();
+    expect(instance).toBeInstanceOf(RedisConnector);
+    expect(redisClientMock.connect).toHaveBeenCalledOnce();
+  });
+
+  it("not call connect after creation", async () => {
+    const instance = await RedisConnector.getInstance();
+    expect(instance).toBeInstanceOf(RedisConnector);
+    expect(redisClientMock.connect).toHaveBeenCalledTimes(0);
+  });
+});

--- a/test/middleware/authentication/middleware.test.ts
+++ b/test/middleware/authentication/middleware.test.ts
@@ -30,7 +30,7 @@ describe("authenticationMiddleware should", () => {
     set: vi.fn(),
   } as unknown as RedisClientType;
   const authTokenCacheKey =
-    "api:auth:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    "api:auth:ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=";
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -133,7 +133,7 @@ describe("authenticationMiddleware should", () => {
     expect(redisClient.set).toHaveBeenCalledWith(
       authTokenCacheKey,
       JSON.stringify(introspectionResult),
-      { EX: 60 },
+      { EX: 300 },
     );
   });
 });

--- a/test/middleware/authentication/middleware.test.ts
+++ b/test/middleware/authentication/middleware.test.ts
@@ -1,7 +1,12 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import type { NextFunction, Request, Response } from "express";
+import type { RedisClientType } from "redis";
 import { authenticationMiddleware } from "@middleware/authentication/middleware";
 import { introspectToken } from "@lib/idp/introspectToken";
+import { RedisConnector } from "@src/lib/redisConnector";
+
+vi.mock("@src/lib/redisConnector");
+const redisConnectorMock = vi.mocked(RedisConnector);
 
 vi.mock("@lib/idp/introspectToken");
 const introspectTokenMock = vi.mocked(introspectToken);
@@ -20,6 +25,12 @@ describe("authenticationMiddleware should", () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Response;
   const mockNext: NextFunction = vi.fn();
+  const redisClient: RedisClientType = {
+    get: vi.fn(),
+    set: vi.fn(),
+  } as unknown as RedisClientType;
+  const authTokenCacheKey =
+    "api:auth:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -34,6 +45,8 @@ describe("authenticationMiddleware should", () => {
     };
 
     mockResponse = buildMockResponse();
+
+    redisConnectorMock.getInstance.mockResolvedValue({ client: redisClient });
   });
 
   it("reject request with there is no authorization header", async () => {
@@ -47,6 +60,8 @@ describe("authenticationMiddleware should", () => {
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(401);
+    expect(redisClient.get).not.toHaveBeenCalled();
+    expect(redisClient.set).not.toHaveBeenCalled();
   });
 
   it("reject request when the authorization header value is invalid", async () => {
@@ -60,6 +75,8 @@ describe("authenticationMiddleware should", () => {
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
+    expect(redisClient.get).toHaveBeenCalledWith(authTokenCacheKey);
+    expect(redisClient.set).not.toHaveBeenCalled();
   });
 
   it("reject request when the form identifier passed in the URL is different than the one associated to the token", async () => {
@@ -73,6 +90,8 @@ describe("authenticationMiddleware should", () => {
 
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockResponse.sendStatus).toHaveBeenCalledWith(403);
+    expect(redisClient.get).toHaveBeenCalledWith(authTokenCacheKey);
+    expect(redisClient.set).not.toHaveBeenCalled();
   });
 
   it("reject request when the token is expired", async () => {
@@ -92,13 +111,16 @@ describe("authenticationMiddleware should", () => {
     expect(mockResponse.json).toHaveBeenCalledWith({
       message: "Token expired",
     });
+    expect(redisClient.get).toHaveBeenCalledWith(authTokenCacheKey);
+    expect(redisClient.set).not.toHaveBeenCalled();
   });
 
   it("accept request when the token is valid, not expired and associated to the form identifier passed in the URL", async () => {
-    introspectTokenMock.mockResolvedValueOnce({
+    const introspectionResult = {
       username: "clzsn6tao000611j50dexeob0",
       exp: Date.now() / 1000 + 100000,
-    });
+    };
+    introspectTokenMock.mockResolvedValueOnce(introspectionResult);
 
     await authenticationMiddleware(
       mockRequest as Request,
@@ -107,5 +129,11 @@ describe("authenticationMiddleware should", () => {
     );
 
     expect(mockNext).toHaveBeenCalled();
+    expect(redisClient.get).toHaveBeenCalledWith(authTokenCacheKey);
+    expect(redisClient.set).toHaveBeenCalledWith(
+      authTokenCacheKey,
+      JSON.stringify(introspectionResult),
+      { EX: 60 },
+    );
   });
 });

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -4,6 +4,7 @@ vi.mock("./src/config", async () => ({
   AWS_REGION: "ca-central-1",
   SERVER_PORT: 3001,
   LOCALSTACK_ENDPOINT: undefined,
+  REDIS_URL: "redis",
   ZITADEL_APPLICATION_KEY: JSON.stringify({
     keyId: "test",
     clientId: "test",
@@ -12,6 +13,10 @@ vi.mock("./src/config", async () => ({
   ZITADEL_DOMAIN: "test",
 }));
 
-vi.mock("node:crypto", () => ({
-  createPrivateKey: vi.fn(),
-}));
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    createPrivateKey: vi.fn(),
+  };
+});


### PR DESCRIPTION
# Summary
Add a Redis connector and logic to cache the access token's introspection result for a short period.  This is being done to improve performance and reduce strain on the IdP.

The Redis connector uses the singleton promise pattern so only one client connection will be shared for requests.

Additionally, the cache expiry time is being kept short and the introspection token response expiry will take
precedence.  This prevents an access token from being kept "valid" past its intended expiration time.

# Testing
1. Generate an access key and token for a form.
2. Perform a request to one of the API's authenticated paths for the form.
3. Expect that on first request, no cached introspection token will be found.
4. Expect that on subsequent requests, a cached token is retrieved and that this cache expires after `60` seconds from the last request.
5. Expect that once the original introspection token response has expired, the cached token is treated as expired.

# TODO
- [x] Add a `REDIS_URL` environment variable to the API's ECS task definition.
- [x] Add unit tests.

# Related
- Closes https://github.com/cds-snc/platform-forms-client/issues/4215