### PR TITLE
feat: handle submission already reported as problematic when using /problem API path

### DIFF
--- a/src/lib/vault/dataStructures/exceptions.ts
+++ b/src/lib/vault/dataStructures/exceptions.ts
@@ -28,3 +28,15 @@ export class FormSubmissionIncorrectConfirmationCodeException extends Error {
     );
   }
 }
+
+// Problem
+
+export class FormSubmissionAlreadyReportedAsProblematicException extends Error {
+  constructor() {
+    super("FormSubmissionAlreadyReportedAsProblematicException");
+    Object.setPrototypeOf(
+      this,
+      FormSubmissionAlreadyReportedAsProblematicException.prototype,
+    );
+  }
+}

--- a/src/routes/forms/submission/submissionName/problem/router.ts
+++ b/src/routes/forms/submission/submissionName/problem/router.ts
@@ -1,5 +1,8 @@
 import express, { type Request, type Response, Router } from "express";
-import { FormSubmissionNotFoundException } from "@src/lib/vault/dataStructures/exceptions";
+import {
+  FormSubmissionAlreadyReportedAsProblematicException,
+  FormSubmissionNotFoundException,
+} from "@src/lib/vault/dataStructures/exceptions";
 import { reportProblemWithFormSubmission } from "@src/lib/vault/reportProblemWithFormSubmission";
 import { notifySupportAboutFormSubmissionProblem } from "@src/lib/support/notifySupportAboutFormSubmissionProblem";
 import type { Schema } from "express-validator";
@@ -66,6 +69,14 @@ problemApiRoute.post(
         return response
           .status(404)
           .json({ error: "Form submission does not exist" });
+      }
+
+      if (
+        error instanceof FormSubmissionAlreadyReportedAsProblematicException
+      ) {
+        return response
+          .status(200)
+          .json({ info: "Form submission is already reported as problematic" });
       }
 
       console.error(

--- a/test/routes/forms/submission/submissionName/problem/router.test.ts
+++ b/test/routes/forms/submission/submissionName/problem/router.test.ts
@@ -3,7 +3,10 @@ import request from "supertest";
 import express, { type Express } from "express";
 import { reportProblemWithFormSubmission } from "@src/lib/vault/reportProblemWithFormSubmission";
 import { problemApiRoute } from "@src/routes/forms/submission/submissionName/problem/router";
-import { FormSubmissionNotFoundException } from "@src/lib/vault/dataStructures/exceptions";
+import {
+  FormSubmissionAlreadyReportedAsProblematicException,
+  FormSubmissionNotFoundException,
+} from "@src/lib/vault/dataStructures/exceptions";
 import { notifySupportAboutFormSubmissionProblem } from "@src/lib/support/notifySupportAboutFormSubmissionProblem";
 
 vi.mock("@lib/vault/reportProblemWithFormSubmission");
@@ -90,6 +93,21 @@ describe("/forms/:formId/submission/:submissionName/problem", () => {
       expect(response.status).toBe(404);
       expect(response.body).toEqual({
         error: "Form submission does not exist",
+      });
+    });
+
+    it("form submission is already reported as problematic", async () => {
+      reportProblemWithFormSubmissionMock.mockRejectedValueOnce(
+        new FormSubmissionAlreadyReportedAsProblematicException(),
+      );
+
+      const response = await request(server)
+        .post("/")
+        .send(buildReportProblemOperationPayload());
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        info: "Form submission is already reported as problematic",
       });
     });
 


### PR DESCRIPTION
# Summary | Résumé

- Handles submissions already reported as problematic when hitting the `/problem` API path with the same submission multiple times