### PR TITLE
refactor: Connector classes with async dependencies

### DIFF
--- a/src/lib/connectors/databaseConnector.ts
+++ b/src/lib/connectors/databaseConnector.ts
@@ -51,8 +51,11 @@ export class DatabaseConnector {
   }
 
   public static async getInstance(): Promise<DatabaseConnector> {
-    // If the promise has not yet been created, create it and the instance
-    if (!DatabaseConnector.connectionStringPromise) {
+    if (DatabaseConnector.connectionStringPromise) {
+      // This is to ensure that any other calls to getInstance() will wait for the connection string to be resolved and the instance to be created
+      await DatabaseConnector.connectionStringPromise;
+    } else {
+      // If the promise has not yet been created, create it and the instance
       DatabaseConnector.connectionStringPromise =
         DatabaseConnector.getConnectionString();
 
@@ -60,9 +63,6 @@ export class DatabaseConnector {
         await DatabaseConnector.connectionStringPromise,
       );
     }
-
-    // This is to ensure that any other calls to getInstance() will wait for the connection string to be resolved and the instance to be created
-    await DatabaseConnector.connectionStringPromise;
 
     return DatabaseConnector.instance;
   }

--- a/src/lib/connectors/redisConnector.ts
+++ b/src/lib/connectors/redisConnector.ts
@@ -6,6 +6,7 @@ export class RedisConnector {
   private static instance: RedisConnector | undefined = undefined;
   private static RETRY_MAX = 10;
   private static RETRY_DELAY_STEP = 500; // milliseconds
+  private static connectionPromise: Promise<RedisClientType>;
 
   public client: RedisClientType;
 
@@ -39,7 +40,12 @@ export class RedisConnector {
   public static async getInstance(): Promise<RedisConnector> {
     if (RedisConnector.instance === undefined) {
       RedisConnector.instance = new RedisConnector();
-      await RedisConnector.instance.client.connect();
+      RedisConnector.connectionPromise =
+        RedisConnector.instance.client.connect();
+      await RedisConnector.connectionPromise;
+    } else {
+      // Ensure all calls to getInstance() wait for the connection to be initialized before returnign the Redis Instance
+      await RedisConnector.connectionPromise;
     }
     return RedisConnector.instance;
   }


### PR DESCRIPTION
# Summary | Résumé
 
Testing over the weekend I was able to find a pattern to reliably create Class instances when dealing with async dependencies.

Redis Connector:
- Add an additional property that holds the `connect()` promise and ensure all subsequent callers await the same promise before returning the initialized instance.

Database Connector:
- Invert the condition and calls to satisfy biome.