### PR TITLE
refactor: return encrypted responses field as base64 string instead of Buffer

### DIFF
--- a/src/lib/connectors/redisConnector.ts
+++ b/src/lib/connectors/redisConnector.ts
@@ -23,11 +23,15 @@ export class RedisConnector {
     });
     this.client
       .on("error", (err: Error) =>
-        logMessage.error(`Redis client error: ${err.message}`),
+        logMessage.error(
+          `[redis-connector] Redis client error: ${err.message}`,
+        ),
       )
-      .on("ready", () => logMessage.debug("Redis client ready!"))
+      .on("ready", () =>
+        logMessage.debug("[redis-connector]  Redis client ready!"),
+      )
       .on("reconnecting", () =>
-        logMessage.debug("Redis client reconnecting..."),
+        logMessage.debug("[redis-connector] Redis client reconnecting..."),
       );
   }
 

--- a/src/lib/vault/encryptFormSubmission.ts
+++ b/src/lib/vault/encryptFormSubmission.ts
@@ -7,10 +7,17 @@ import {
   publicEncrypt,
 } from "node:crypto";
 
+export interface EncryptedFormSubmission {
+  encryptedResponses: string;
+  encryptedKey: string;
+  encryptedNonce: string;
+  encryptedAuthTag: string;
+}
+
 export const encryptFormSubmission = async (
   serviceAccountId: string,
   submission: FormSubmission,
-) => {
+): Promise<EncryptedFormSubmission> => {
   const serviceAccountPublicKey = await getPublicKey(serviceAccountId);
 
   // Encrypt the submission with the public key
@@ -22,7 +29,7 @@ export const encryptFormSubmission = async (
   const encryptedResponses = Buffer.concat([
     cipher.update(Buffer.from(JSON.stringify(submission))),
     cipher.final(),
-  ]);
+  ]).toString("base64");
   const authTag = cipher.getAuthTag();
   const publicKey = createPublicKey({ key: serviceAccountPublicKey });
   const encryptedKey = publicEncrypt(publicKey, encryptionKey).toString(

--- a/src/routes/forms/formId/submission/submissionName/router.ts
+++ b/src/routes/forms/formId/submission/submissionName/router.ts
@@ -34,12 +34,12 @@ submissionNameApiRoute.get(
         );
       }
 
-      const encryptedSubmission = await encryptFormSubmission(
+      const encryptedFormSubmission = await encryptFormSubmission(
         serviceAccountId,
         formSubmission,
       );
 
-      return response.json(encryptedSubmission);
+      return response.json(encryptedFormSubmission);
     } catch (error) {
       logMessage.error(
         `[route] Internal error while serving request: /forms/${formId}/submission/${submissionName}. Reason: ${JSON.stringify(

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,5 +9,7 @@ const server: Express = express();
 server.use("/", router);
 
 server.listen(SERVER_PORT, () => {
-  logMessage.info(`>>> API server listening on port ${SERVER_PORT} <<<`);
+  logMessage.info(
+    `[express-server] API server listening on port ${SERVER_PORT}`,
+  );
 });


### PR DESCRIPTION
# Summary | Résumé

- Modifies the `encryptedResponses` property type from Buffer to string (base64 encoded)