### PR TITLE
feat: add API client example in .NET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 build/
 .pnpm-store
 *private_api_key.json
+bin/
+obj/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
   "editor.formatOnSave": true,
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[csharp]": {
+    "editor.defaultFormatter": "ms-dotnettools.csharp"
   }
 }

--- a/examples/.NET/AccessTokenGenerator.cs
+++ b/examples/.NET/AccessTokenGenerator.cs
@@ -1,0 +1,76 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+
+namespace dotnet
+{
+  public class AccessTokenGenerator
+  {
+    public static async Task<string> Generate(string identityProviderUrl, string projectIdentifier, PrivateApiKey privateApiKey)
+    {
+      try
+      {
+        RSA rsa = RSA.Create();
+
+        rsa.ImportFromPem(privateApiKey.key);
+
+        RsaSecurityKey rsaSecurityKey = new(rsa)
+        {
+          KeyId = privateApiKey.keyId,
+        };
+
+        SigningCredentials signingCredentials = new(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+
+        JwtSecurityToken jwtSecurityToken = new(
+          claims: [
+            new Claim("iat", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer),
+            new Claim("iss", privateApiKey.userId),
+            new Claim("sub", privateApiKey.userId),
+            new Claim("aud", identityProviderUrl),
+            new Claim("exp", ((DateTimeOffset)DateTime.UtcNow.AddHours(1)).ToUnixTimeSeconds().ToString(), ClaimValueTypes.Integer)
+          ],
+          signingCredentials: signingCredentials
+        );
+
+        string jwtSignedToken = new JwtSecurityTokenHandler().WriteToken(jwtSecurityToken);
+
+        Dictionary<string, string> requestParameters = new()
+        {
+          { "grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer" },
+          { "assertion", jwtSignedToken },
+          { "scope", $"openid profile urn:zitadel:iam:org:project:id:{projectIdentifier}:aud" }
+        };
+
+        HttpClient httpClient = new()
+        {
+          BaseAddress = new Uri(identityProviderUrl),
+          Timeout = TimeSpan.FromSeconds(3)
+        };
+
+        // For the API to accept requests we need to set the `User-Agent` header parameter
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "AccessTokenGenerator/1.0");
+
+        TokenResponse response = await httpClient.PostAsync(
+            "/oauth/v2/token",
+            new FormUrlEncodedContent(requestParameters)
+          )
+          .Result
+          .Content
+          .ReadFromJsonAsync<TokenResponse>();
+
+        return response.access_token;
+      }
+      catch (Exception exception)
+      {
+        throw new Exception("Failed to generate access token", exception);
+      }
+    }
+
+    private struct TokenResponse
+    {
+      public required string access_token { get; set; }
+    }
+  }
+}

--- a/examples/.NET/DataStructures.cs
+++ b/examples/.NET/DataStructures.cs
@@ -1,0 +1,27 @@
+namespace dotnet
+{
+  public struct PrivateApiKey
+  {
+    public required string keyId { get; set; }
+    public required string key { get; set; }
+    public required string userId { get; set; }
+  }
+
+  public struct NewFormSubmission
+  {
+    public required string name { get; set; }
+  }
+
+  public struct EncryptedFormSubmission
+  {
+    public required string encryptedResponses { get; set; }
+    public required string encryptedKey { get; set; }
+    public required string encryptedNonce { get; set; }
+    public required string encryptedAuthTag { get; set; }
+  }
+
+  public struct FormSubmission
+  {
+    public required string confirmationCode { get; set; }
+  }
+}

--- a/examples/.NET/FormSubmissionDecrypter.cs
+++ b/examples/.NET/FormSubmissionDecrypter.cs
@@ -1,0 +1,36 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace dotnet
+{
+  public class FormSubmissionDecrypter
+  {
+    public static string Decrypt(EncryptedFormSubmission encryptedSubmission, PrivateApiKey privateApiKey)
+    {
+      try
+      {
+        RSA rsa = RSA.Create();
+
+        rsa.ImportFromPem(privateApiKey.key);
+
+        byte[] decryptedKey = rsa.Decrypt(Convert.FromBase64String(encryptedSubmission.encryptedKey), RSAEncryptionPadding.OaepSHA256);
+        byte[] decryptedNonce = rsa.Decrypt(Convert.FromBase64String(encryptedSubmission.encryptedNonce), RSAEncryptionPadding.OaepSHA256);
+        byte[] decryptedAuthTag = rsa.Decrypt(Convert.FromBase64String(encryptedSubmission.encryptedAuthTag), RSAEncryptionPadding.OaepSHA256);
+
+        byte[] encryptedData = Convert.FromBase64String(encryptedSubmission.encryptedResponses);
+
+        AesGcm aesGcm = new(decryptedKey, 16);
+
+        byte[] decryptedData = new byte[encryptedData.Length];
+
+        aesGcm.Decrypt(decryptedNonce, encryptedData, decryptedAuthTag, decryptedData);
+
+        return Encoding.UTF8.GetString(decryptedData);
+      }
+      catch (Exception exception)
+      {
+        throw new Exception("Failed to decrypt form submission", exception);
+      }
+    }
+  }
+}

--- a/examples/.NET/GCFormsApiClient.cs
+++ b/examples/.NET/GCFormsApiClient.cs
@@ -1,0 +1,94 @@
+﻿using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace dotnet
+{
+  public class GCFormsApiClient
+  {
+    private readonly HttpClient httpClient;
+
+    public GCFormsApiClient(string apiUrl, string accessToken)
+    {
+      this.httpClient = new HttpClient()
+      {
+        BaseAddress = new Uri(apiUrl),
+        Timeout = TimeSpan.FromSeconds(3),
+      };
+
+      // For the API to accept requests we need to set the `User-Agent` header parameter
+      this.httpClient.DefaultRequestHeaders.Add("User-Agent", "GCFormsApiClient/1.0");
+
+      this.httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+    }
+
+    public Task<object> GetFormTemplate(string formId)
+    {
+      try
+      {
+        return this
+          .httpClient
+          .GetAsync($"/forms/{formId}/template")
+          .Result
+          .EnsureSuccessStatusCode()
+          .Content
+          .ReadFromJsonAsync<object>();
+      }
+      catch (Exception exception)
+      {
+        throw new Exception("Failed to retrieve form template", exception);
+      }
+    }
+
+    public Task<List<NewFormSubmission>> GetNewFormSubmissions(string formId)
+    {
+      try
+      {
+        return this
+          .httpClient
+          .GetAsync($"/forms/{formId}/submission/new")
+          .Result
+          .EnsureSuccessStatusCode()
+          .Content
+          .ReadFromJsonAsync<List<NewFormSubmission>>();
+      }
+      catch (Exception exception)
+      {
+        throw new Exception("Failed to retrieve new form submissions", exception);
+      }
+    }
+
+    public Task<EncryptedFormSubmission> GetFormSubmission(string formId, string submissionName)
+    {
+      try
+      {
+        return this
+          .httpClient
+          .GetAsync($"/forms/{formId}/submission/{submissionName}")
+          .Result
+          .EnsureSuccessStatusCode()
+          .Content
+          .ReadFromJsonAsync<EncryptedFormSubmission>();
+      }
+      catch (Exception exception)
+      {
+        throw new Exception("Failed to retrieve form submission", exception);
+      }
+    }
+
+    public async Task ConfirmFormSubmission(string formId, string submissionName, string confirmationCode)
+    {
+      try
+      {
+        HttpResponseMessage response = await this
+          .httpClient
+          .PutAsync($"/forms/{formId}/submission/{submissionName}/confirm/{confirmationCode}", null);
+
+        response.EnsureSuccessStatusCode();
+      }
+      catch (Exception exception)
+      {
+        throw new Exception("Failed to confirm form submission", exception);
+      }
+    }
+  }
+}

--- a/examples/.NET/Program.cs
+++ b/examples/.NET/Program.cs
@@ -18,7 +18,7 @@ namespace dotnet
         Console.WriteLine(@"
 I want to:
 (1) Generate and display an access token
-(2) Retrieve a form submission
+(2) Retrieve, decrypt and confirm form submissions
 Selection (1):
 ");
 

--- a/examples/.NET/Program.cs
+++ b/examples/.NET/Program.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using System.Text.Json;
+
+namespace dotnet
+{
+  class Program
+  {
+    static readonly string IDENTITY_PROVIDER_URL = "";
+    static readonly string PROJECT_IDENTIFIER = "";
+    static readonly string GCFORMS_API_URL = "";
+
+    static async Task Main(string[] args)
+    {
+      try
+      {
+        PrivateApiKey privateApiKey = LoadPrivateApiKey();
+
+        Console.WriteLine(@"
+I want to:
+(1) Generate and display an access token
+(2) Retrieve a form submission
+Selection (1):
+");
+
+        switch (Console.ReadLine())
+        {
+          case "1":
+          default:
+            {
+              Console.WriteLine("\nGenerating access token...");
+              string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
+
+              Console.WriteLine("\nGenerated access token:");
+              Console.WriteLine(accessToken);
+            }
+            break;
+          case "2":
+            {
+              Console.WriteLine("\nForm ID to retrieve responses for:");
+
+              string formId = Console.ReadLine();
+
+              Console.WriteLine("\nGenerating access token...");
+
+              string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
+
+              GCFormsApiClient apiClient = new(GCFORMS_API_URL, accessToken);
+
+              Console.WriteLine("\nRetrieving form template...\n");
+
+              object formTemplate = await apiClient.GetFormTemplate(formId);
+
+              Console.WriteLine(formTemplate);
+
+              Console.WriteLine("\nRetrieving new form submissions...");
+
+              List<NewFormSubmission> newFormSubmissions = await apiClient.GetNewFormSubmissions(formId);
+
+              if (newFormSubmissions.Count > 0)
+              {
+                Console.WriteLine($"\nNew form submissions:");
+                Console.WriteLine(string.Join(", ", newFormSubmissions.Select(x => x.name)));
+
+                Console.WriteLine("\nRetrieving, decrypting and confirming form submissions...");
+
+                foreach (NewFormSubmission submission in newFormSubmissions)
+                {
+                  Console.WriteLine($"\nProcessing {submission.name}...\n");
+
+                  Console.WriteLine("Retrieving encrypted submission...");
+
+                  EncryptedFormSubmission encryptedSubmission = await apiClient.GetFormSubmission(formId, submission.name);
+
+                  Console.WriteLine("\nEncrypted submission:");
+                  Console.WriteLine(encryptedSubmission.encryptedResponses);
+
+                  Console.WriteLine("\nDecrypting submission...");
+
+                  string decryptedFormSubmission = FormSubmissionDecrypter.Decrypt(encryptedSubmission, privateApiKey);
+
+                  Console.WriteLine("\nDecrypted submission:");
+                  Console.WriteLine(decryptedFormSubmission);
+
+                  FormSubmission formSubmission = JsonSerializer.Deserialize<FormSubmission>(decryptedFormSubmission);
+
+                  Console.WriteLine("\nConfirming submission...");
+
+                  await apiClient.ConfirmFormSubmission(formId, submission.name, formSubmission.confirmationCode);
+
+                  Console.WriteLine("\n=> Press any key to continue processing form submissions or Ctrl-C to exit");
+                  Console.ReadKey();
+                }
+              }
+              else
+              {
+                Console.WriteLine($"\nCould not find any new form submission!");
+              }
+            }
+            break;
+        }
+      }
+      catch (Exception exception)
+      {
+        Console.WriteLine(exception.ToString());
+      }
+    }
+
+    static PrivateApiKey LoadPrivateApiKey()
+    {
+      try
+      {
+        string[] files = Directory.GetFiles(Directory.GetCurrentDirectory(), "*_private_api_key.json");
+
+        if (files.Length != 1)
+        {
+          throw new Exception("Private API key file is either missing or there is more than one in the directory");
+        }
+
+        string privateKeyAsJsonString = File.ReadAllText(files[0], Encoding.UTF8);
+
+        return JsonSerializer.Deserialize<PrivateApiKey>(privateKeyAsJsonString);
+      }
+      catch (Exception exception)
+      {
+        throw new Exception("Failed to load private API key", exception);
+      }
+
+    }
+  }
+}
+

--- a/examples/.NET/Program.cs
+++ b/examples/.NET/Program.cs
@@ -5,9 +5,9 @@ namespace dotnet
 {
   class Program
   {
-    static readonly string IDENTITY_PROVIDER_URL = "";
-    static readonly string PROJECT_IDENTIFIER = "";
-    static readonly string GCFORMS_API_URL = "";
+    static readonly string IDENTITY_PROVIDER_URL = "https://auth.forms-formulaires.alpha.canada.ca";
+    static readonly string PROJECT_IDENTIFIER = "284778202772022819";
+    static readonly string GCFORMS_API_URL = "https://api.forms-formulaires.alpha.canada.ca";
 
     static async Task Main(string[] args)
     {

--- a/examples/.NET/README.md
+++ b/examples/.NET/README.md
@@ -4,7 +4,7 @@
 
 - Download and install .NET version 8.0
   - (with Microsoft installer) https://dotnet.microsoft.com/en-us/download
-  - (with Brew) `brew install --cask dotnet`
+  - (with Brew) `brew install --cask dotnet-sdk`
 
 To make sure .NET is properly installed, try to run the following command `dotnet --version`.
 

--- a/examples/.NET/README.md
+++ b/examples/.NET/README.md
@@ -1,0 +1,23 @@
+# GC Forms API client example in .NET
+
+## Prerequisites
+
+- Download and install .NET version 8.0
+  - (with Microsoft installer) https://dotnet.microsoft.com/en-us/download
+  - (with Brew) `brew install --cask dotnet`
+
+To make sure .NET is properly installed, try to run the following command `dotnet --version`.
+
+## How to setup application
+
+- Put the private key file you have generated through the GCForms web application in this folder next to the `Program.cs` file. Make sure the file name ends with `_private_api_key.json`
+- In the `Program.cs` file set the following variables:
+  - `IDENTITY_PROVIDER_URL`: This is the URL of the identity provider (IDP)
+  - `PROJECT_IDENTIFIER`: This is the GCForms project identifier in the IDP
+  - `GCFORMS_API_URL`: This is the URL of the GCForms API
+
+## How to run application
+
+```shell
+$ dotnet run
+```

--- a/examples/.NET/README.md
+++ b/examples/.NET/README.md
@@ -11,10 +11,6 @@ To make sure .NET is properly installed, try to run the following command `dotne
 ## How to setup application
 
 - Put the private key file you have generated through the GCForms web application in this folder next to the `Program.cs` file. Make sure the file name ends with `_private_api_key.json`
-- In the `Program.cs` file set the following variables:
-  - `IDENTITY_PROVIDER_URL`: This is the URL of the identity provider (IDP)
-  - `PROJECT_IDENTIFIER`: This is the GCForms project identifier in the IDP
-  - `GCFORMS_API_URL`: This is the URL of the GCForms API
 
 ## How to run application
 

--- a/examples/.NET/dotnet.csproj
+++ b/examples/.NET/dotnet.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.2" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Summary | Résumé

- Adds API client example in .NET

# Tests

- Follow directions in README.md file located in the .NET example folder