### PR TITLE
feat: add API client example in Node.js

### DIFF
--- a/examples/.NET/Program.cs
+++ b/examples/.NET/Program.cs
@@ -5,9 +5,9 @@ namespace dotnet
 {
   class Program
   {
-    static readonly string IDENTITY_PROVIDER_URL = "https://auth.forms-formulaires.alpha.canada.ca";
-    static readonly string PROJECT_IDENTIFIER = "284778202772022819";
-    static readonly string GCFORMS_API_URL = "https://api.forms-formulaires.alpha.canada.ca";
+    static readonly string IDENTITY_PROVIDER_URL = "https://auth.forms-staging.cdssandbox.xyz";
+    static readonly string PROJECT_IDENTIFIER = "275372254274006635";
+    static readonly string GCFORMS_API_URL = "https://api.forms-staging.cdssandbox.xyz";
 
     static async Task Main(string[] args)
     {

--- a/examples/.NET/Program.cs
+++ b/examples/.NET/Program.cs
@@ -63,13 +63,13 @@ Selection (1):
 
                 Console.WriteLine("\nRetrieving, decrypting and confirming form submissions...");
 
-                foreach (NewFormSubmission submission in newFormSubmissions)
+                foreach (NewFormSubmission newFormSubmission in newFormSubmissions)
                 {
-                  Console.WriteLine($"\nProcessing {submission.name}...\n");
+                  Console.WriteLine($"\nProcessing {newFormSubmission.name}...\n");
 
                   Console.WriteLine("Retrieving encrypted submission...");
 
-                  EncryptedFormSubmission encryptedSubmission = await apiClient.GetFormSubmission(formId, submission.name);
+                  EncryptedFormSubmission encryptedSubmission = await apiClient.GetFormSubmission(formId, newFormSubmission.name);
 
                   Console.WriteLine("\nEncrypted submission:");
                   Console.WriteLine(encryptedSubmission.encryptedResponses);
@@ -85,7 +85,9 @@ Selection (1):
 
                   Console.WriteLine("\nConfirming submission...");
 
-                  await apiClient.ConfirmFormSubmission(formId, submission.name, formSubmission.confirmationCode);
+                  await apiClient.ConfirmFormSubmission(formId, newFormSubmission.name, formSubmission.confirmationCode);
+
+                  Console.WriteLine("\nSubmission confirmed");
 
                   Console.WriteLine("\n=> Press any key to continue processing form submissions or Ctrl-C to exit");
                   Console.ReadKey();

--- a/examples/Node.js/README.md
+++ b/examples/Node.js/README.md
@@ -1,0 +1,20 @@
+# GC Forms API client example in Node.js
+
+## Prerequisites
+
+- Download and install Node.js version 22
+  - (with Node.js installer) https://nodejs.org/en/download/prebuilt-installer
+  - (with Brew) `brew install node@22`
+
+To make sure Node.js is properly installed, try to run the following command `node --version`.
+
+## How to setup application
+
+- Put the private key file you have generated through the GCForms web application in this folder next to the `index.ts` file. Make sure the file name ends with `_private_api_key.json`
+- Install required dependencies by running the following command `npm install`
+
+## How to run application
+
+```shell
+$ npm start
+```

--- a/examples/Node.js/accessTokenGenerator.ts
+++ b/examples/Node.js/accessTokenGenerator.ts
@@ -1,0 +1,42 @@
+import { createPrivateKey } from "node:crypto";
+import { SignJWT } from "jose";
+import axios from "axios";
+import type { PrivateApiKey } from "./dataStructures.js";
+
+export function generateAccessToken(
+  identityProviderUrl: string,
+  projectIdentifier: string,
+  privateApiKey: PrivateApiKey,
+): Promise<string> {
+  const privateKey = createPrivateKey({ key: privateApiKey.key });
+
+  const jsonWebTokenSigner = new SignJWT()
+    .setProtectedHeader({ alg: "RS256", kid: privateApiKey.keyId })
+    .setIssuedAt()
+    .setIssuer(privateApiKey.userId)
+    .setSubject(privateApiKey.userId)
+    .setAudience(identityProviderUrl)
+    .setExpirationTime("1h");
+
+  return jsonWebTokenSigner
+    .sign(privateKey)
+    .then((signedJsonWebToken) =>
+      axios.post(
+        `${identityProviderUrl}/oauth/v2/token`,
+        {
+          grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          assertion: signedJsonWebToken,
+          scope: `openid profile urn:zitadel:iam:org:project:id:${projectIdentifier}:aud`,
+        },
+        {
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        },
+      ),
+    )
+    .then((response) => response.data.access_token as string)
+    .catch((error) => {
+      throw new Error("Failed to generate access token", { cause: error });
+    });
+}

--- a/examples/Node.js/dataStructures.ts
+++ b/examples/Node.js/dataStructures.ts
@@ -1,0 +1,22 @@
+export interface PrivateApiKey {
+  keyId: string;
+  key: string;
+  userId: string;
+}
+
+export type FormTemplate = Record<string, unknown>;
+
+export interface NewFormSubmission {
+  name: string;
+}
+
+export interface EncryptedFormSubmission {
+  encryptedResponses: string;
+  encryptedKey: string;
+  encryptedNonce: string;
+  encryptedAuthTag: string;
+}
+
+export interface FormSubmission {
+  confirmationCode: string;
+}

--- a/examples/Node.js/formSubmissionDecrypter.ts
+++ b/examples/Node.js/formSubmissionDecrypter.ts
@@ -1,0 +1,50 @@
+import { privateDecrypt, createDecipheriv } from "node:crypto";
+import type {
+  EncryptedFormSubmission,
+  PrivateApiKey,
+} from "./dataStructures.js";
+
+export function decryptFormSubmission(
+  encryptedSubmission: EncryptedFormSubmission,
+  privateApiKey: PrivateApiKey,
+): string {
+  const privateKey = {
+    key: privateApiKey.key,
+    oaepHash: "sha256",
+  };
+
+  const decryptedKey = privateDecrypt(
+    privateKey,
+    Buffer.from(encryptedSubmission.encryptedKey, "base64"),
+  );
+
+  const decryptedNonce = privateDecrypt(
+    privateKey,
+    Buffer.from(encryptedSubmission.encryptedNonce, "base64"),
+  );
+
+  const decryptedAuthTag = privateDecrypt(
+    privateKey,
+    Buffer.from(encryptedSubmission.encryptedAuthTag, "base64"),
+  );
+
+  const gcmDecipher = createDecipheriv(
+    "aes-256-gcm",
+    decryptedKey,
+    decryptedNonce,
+  );
+
+  gcmDecipher.setAuthTag(decryptedAuthTag);
+
+  const encryptedData = Buffer.from(
+    encryptedSubmission.encryptedResponses,
+    "base64",
+  );
+
+  const decryptedData = Buffer.concat([
+    gcmDecipher.update(encryptedData),
+    gcmDecipher.final(),
+  ]);
+
+  return decryptedData.toString("utf8");
+}

--- a/examples/Node.js/gcFormsApiClient.ts
+++ b/examples/Node.js/gcFormsApiClient.ts
@@ -1,0 +1,69 @@
+import axios, { type AxiosInstance } from "axios";
+import type {
+  EncryptedFormSubmission,
+  FormTemplate,
+  NewFormSubmission,
+} from "./dataStructures.js";
+
+export class GCFormsApiClient {
+  private httpClient: AxiosInstance;
+
+  public constructor(apiUrl: string, accessToken: string) {
+    this.httpClient = axios.create({
+      baseURL: apiUrl,
+      timeout: 3000,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  }
+
+  public getFormTemplate(formId: string): Promise<FormTemplate> {
+    return this.httpClient
+      .get<FormTemplate>(`/forms/${formId}/template`)
+      .then((response) => response.data)
+      .catch((error) => {
+        throw new Error("Failed to retrieve form template", { cause: error });
+      });
+  }
+
+  public getNewFormSubmissions(formId: string): Promise<NewFormSubmission[]> {
+    return this.httpClient
+      .get<NewFormSubmission[]>(`/forms/${formId}/submission/new`)
+      .then((response) => response.data)
+      .catch((error) => {
+        throw new Error("Failed to retrieve new form submissions", {
+          cause: error,
+        });
+      });
+  }
+
+  public getFormSubmission(
+    formId: string,
+    submissionName: string,
+  ): Promise<EncryptedFormSubmission> {
+    return this.httpClient
+      .get<EncryptedFormSubmission>(
+        `/forms/${formId}/submission/${submissionName}`,
+      )
+      .then((response) => response.data)
+      .catch((error) => {
+        throw new Error("Failed to retrieve form submission", { cause: error });
+      });
+  }
+
+  public confirmFormSubmission(
+    formId: string,
+    submissionName: string,
+    confirmationCode: string,
+  ): Promise<void> {
+    return this.httpClient
+      .put<void>(
+        `/forms/${formId}/submission/${submissionName}/confirm/${confirmationCode}`,
+      )
+      .then((_) => {
+        // success
+      })
+      .catch((error) => {
+        throw new Error("Failed to confirm form submission", { cause: error });
+      });
+  }
+}

--- a/examples/Node.js/index.ts
+++ b/examples/Node.js/index.ts
@@ -5,9 +5,9 @@ import { generateAccessToken } from "./accessTokenGenerator.js";
 import { GCFormsApiClient } from "./gcFormsApiClient.js";
 import { decryptFormSubmission } from "./formSubmissionDecrypter.js";
 
-const IDENTITY_PROVIDER_URL = "https://auth.forms-formulaires.alpha.canada.ca";
-const PROJECT_IDENTIFIER = "284778202772022819";
-const GCFORMS_API_URL = "https://api.forms-formulaires.alpha.canada.ca";
+const IDENTITY_PROVIDER_URL = "https://auth.forms-staging.cdssandbox.xyz";
+const PROJECT_IDENTIFIER = "275372254274006635";
+const GCFORMS_API_URL = "https://api.forms-staging.cdssandbox.xyz";
 
 async function main() {
   try {

--- a/examples/Node.js/index.ts
+++ b/examples/Node.js/index.ts
@@ -1,0 +1,167 @@
+import readline from "node:readline";
+import filesystem from "node:fs/promises";
+import type { FormSubmission, PrivateApiKey } from "./dataStructures.js";
+import { generateAccessToken } from "./accessTokenGenerator.js";
+import { GCFormsApiClient } from "./gcFormsApiClient.js";
+import { decryptFormSubmission } from "./formSubmissionDecrypter.js";
+
+const IDENTITY_PROVIDER_URL = "https://auth.forms-formulaires.alpha.canada.ca";
+const PROJECT_IDENTIFIER = "284778202772022819";
+const GCFORMS_API_URL = "https://api.forms-formulaires.alpha.canada.ca";
+
+async function main() {
+  try {
+    const privateApiKey = await loadPrivateKey();
+
+    const menuSelection = await requestUserInput(`
+I want to:
+(1) Generate and display an access token
+(2) Retrieve, decrypt and confirm form submissions
+Selection (1):
+`);
+
+    switch (menuSelection) {
+      case "2": {
+        const formId = await requestUserInput(
+          "\nForm ID to retrieve responses for:\n",
+        );
+
+        console.info("\nGenerating access token...");
+
+        const accessToken = await generateAccessToken(
+          IDENTITY_PROVIDER_URL,
+          PROJECT_IDENTIFIER,
+          privateApiKey,
+        );
+
+        const apiClient = new GCFormsApiClient(GCFORMS_API_URL, accessToken);
+
+        console.info("\nRetrieving form template...\n");
+
+        const formTemplate = await apiClient.getFormTemplate(formId);
+
+        console.info(formTemplate);
+
+        console.info("\nRetrieving new form submissions...");
+
+        const newFormSubmissions =
+          await apiClient.getNewFormSubmissions(formId);
+
+        if (newFormSubmissions.length > 0) {
+          console.info("\nNew form submissions:");
+          console.info(newFormSubmissions.map((x) => x.name).join(", "));
+
+          console.info(
+            "\nRetrieving, decrypting and confirming form submissions...",
+          );
+
+          for (const newFormSubmission of newFormSubmissions) {
+            console.info(`\nProcessing ${newFormSubmission.name}...\n`);
+
+            console.info("Retrieving encrypted submission...");
+
+            const encryptedSubmission = await apiClient.getFormSubmission(
+              formId,
+              newFormSubmission.name,
+            );
+
+            console.info("\nEncrypted submission:");
+            console.info(encryptedSubmission.encryptedResponses);
+
+            console.info("\nDecrypting submission...");
+
+            const decryptedFormSubmission = decryptFormSubmission(
+              encryptedSubmission,
+              privateApiKey,
+            );
+
+            console.info("\nDecrypted submission:");
+            console.info(decryptedFormSubmission);
+
+            const formSubmission = JSON.parse(
+              decryptedFormSubmission,
+            ) as FormSubmission;
+
+            console.info("\nConfirming submission...");
+
+            await apiClient.confirmFormSubmission(
+              formId,
+              newFormSubmission.name,
+              formSubmission.confirmationCode,
+            );
+
+            console.info("\nSubmission confirmed");
+
+            await requestUserInput(
+              "\n=> Press any key to continue processing form submissions or Ctrl-C to exit",
+            );
+          }
+        } else {
+          console.info("\nCould not find any new form submission!");
+        }
+        break;
+      }
+
+      default: {
+        console.info("\nGenerating access token...");
+
+        const accessToken = await generateAccessToken(
+          IDENTITY_PROVIDER_URL,
+          PROJECT_IDENTIFIER,
+          privateApiKey,
+        );
+
+        console.info("\nGenerated access token:");
+        console.info(accessToken);
+        break;
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function loadPrivateKey(): Promise<PrivateApiKey> {
+  return filesystem
+    .readdir(".")
+    .then((files) => {
+      const validFiles = files.filter((fileName) =>
+        fileName.endsWith("_private_api_key.json"),
+      );
+
+      if (validFiles.length !== 1) {
+        throw new Error(
+          "Private API key file is either missing or there is more than one in the directory",
+        );
+      }
+
+      return validFiles[0];
+    })
+    .then((privateApiKeyFileName) => {
+      return filesystem.readFile(`./${privateApiKeyFileName}`, {
+        encoding: "utf8",
+      });
+    })
+    .then((privateKeyAsJsonString) => {
+      return JSON.parse(privateKeyAsJsonString) as PrivateApiKey;
+    })
+    .catch((error) => {
+      throw new Error("Failed to load private API key", { cause: error });
+    });
+}
+
+function requestUserInput(question: string): Promise<string> {
+  const readlineInterface = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise<string>((resolve) =>
+    readlineInterface.question(question, (response) => {
+      readlineInterface.close();
+      resolve(response);
+    }),
+  );
+}
+
+main();

--- a/examples/Node.js/package-lock.json
+++ b/examples/Node.js/package-lock.json
@@ -1,0 +1,131 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.7.7",
+        "jose": "^5.9.2"
+      },
+      "devDependencies": {
+        "typescript": "^5.6.2"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.2.tgz",
+      "integrity": "sha512-ILI2xx/I57b20sd7rHZvgiiQrmp2mcotwsAH+5ajbpFQbrYVQdNHYlQhoA5cFb78CgtBOxtC05TeA+mcgkuCqQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/typescript": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/examples/Node.js/package.json
+++ b/examples/Node.js/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "node",
+  "version": "1.0.0",
+  "description": "GC Forms API client example in Typescript with Node.js",
+  "type": "module",
+  "scripts": {
+    "start": "npx tsc -p tsconfig.json && node build/index.js"
+  },
+  "author": "Canadian Digital Service",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^1.7.7",
+    "jose": "^5.9.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.2"
+  }
+}

--- a/examples/Node.js/tsconfig.json
+++ b/examples/Node.js/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "outDir": "build"
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

- Adds API client example in Node.js
- Modifies example programs so that it points to our Staging environment by default. This is because we will be testing V1 in Staging to begin with.

# Tests

- Follow directions in README.md file located in the Node.js example folder