### PR TITLE
feature: Add integrity check and update Node example

### DIFF
--- a/examples/nodejs/formIntegrityVerification.ts
+++ b/examples/nodejs/formIntegrityVerification.ts
@@ -1,0 +1,6 @@
+import { createHash } from "node:crypto";
+
+export const verifyIntegrity = (submission: string, hash: string) => {
+  const hashBuffer = createHash("md5").update(submission).digest("hex");
+  return hashBuffer.toString() === hash;
+};

--- a/examples/nodejs/index.ts
+++ b/examples/nodejs/index.ts
@@ -4,6 +4,7 @@ import type { FormSubmission, PrivateApiKey } from "./types.js";
 import { generateAccessToken } from "./accessTokenGenerator.js";
 import { GCFormsApiClient } from "./gcFormsApiClient.js";
 import { decryptFormSubmission } from "./formSubmissionDecrypter.js";
+import { verifyIntegrity } from "./formIntegrityVerification.js";
 
 const IDENTITY_PROVIDER_URL = "https://auth.forms-staging.cdssandbox.xyz";
 const PROJECT_IDENTIFIER = "275372254274006635";
@@ -81,6 +82,16 @@ Selection (1):
             const formSubmission = JSON.parse(
               decryptedFormSubmission,
             ) as FormSubmission;
+
+            console.info("\nVerifying submission integrity...");
+
+            const verified = verifyIntegrity(
+              formSubmission.answers,
+              formSubmission.checksum,
+            );
+            console.info(
+              `Submission Integrity: ${verified ? "OK" : "INVALID"}`,
+            );
 
             console.info("\nConfirming submission...");
 

--- a/examples/nodejs/types.d.ts
+++ b/examples/nodejs/types.d.ts
@@ -8,6 +8,7 @@ export type FormTemplate = Record<string, unknown>;
 
 export interface NewFormSubmission {
   name: string;
+  createdAt: number;
 }
 
 export interface EncryptedFormSubmission {
@@ -18,5 +19,16 @@ export interface EncryptedFormSubmission {
 }
 
 export interface FormSubmission {
+  createdAt: number;
+  status: FormSubmissionStatus;
   confirmationCode: string;
+  answers: string;
+  checksum: string;
+}
+
+export enum FormSubmissionStatus {
+  New = "New",
+  Downloaded = "Downloaded",
+  Confirmed = "Confirmed",
+  Problem = "Problem",
 }

--- a/src/lib/vault/dataStructures/formSubmission.ts
+++ b/src/lib/vault/dataStructures/formSubmission.ts
@@ -10,6 +10,7 @@ export interface FormSubmission {
   status: FormSubmissionStatus;
   confirmationCode: string;
   answers: string;
+  checksum: string;
 }
 
 export interface NewFormSubmission {
@@ -25,6 +26,7 @@ export function formSubmissionFromDynamoDbResponse(
     status: response.Status as FormSubmissionStatus,
     confirmationCode: response.ConfirmationCode as string,
     answers: response.FormSubmission as string,
+    checksum: response.FormSubmissionHash as string,
   };
 }
 

--- a/src/lib/vault/getFormSubmission.ts
+++ b/src/lib/vault/getFormSubmission.ts
@@ -17,7 +17,7 @@ export async function getFormSubmission(
           TableName: "Vault",
           Key: { FormID: formId, NAME_OR_CONF: `NAME#${submissionName}` },
           ProjectionExpression:
-            "CreatedAt,#status,ConfirmationCode,FormSubmission",
+            "CreatedAt,#status,ConfirmationCode,FormSubmission,FormSubmissionHash",
           ExpressionAttributeNames: {
             "#status": "Status",
           },

--- a/utils/responseRetriever/main.ts
+++ b/utils/responseRetriever/main.ts
@@ -126,6 +126,11 @@ const decryptSubmission = (
   ]).toString("utf-8");
 };
 
+const verifyIntegrity = (submission: string, hash: string) => {
+  const hashBuffer = crypto.createHash("md5").update(submission).digest("hex");
+  return hashBuffer.toString() === hash;
+};
+
 const confirmSubmission = async (
   submission: {
     createdAt: number;
@@ -233,6 +238,10 @@ Selection (1): `);
       console.info(`Decrypted submission for ${name}:`);
       console.info(decryptedSubmission);
       const submission = JSON.parse(decryptedSubmission);
+
+      console.info(
+        `Integrity check for ${name}: ${verifyIntegrity(submission.answers, submission.checksum)}`,
+      );
 
       const result = await confirmSubmission(
         submission,


### PR DESCRIPTION
# Summary | Résumé
Adds integrity check to utility script and NodeJS example.
API server now returns FormSubmissionChecksum as part of response download.

Out of scope for now is to update the .Net example.  It will be tackled in a later PR after the API Server is returning the new checksum value.

