### PR TITLE
fix: allow SBOM to be written to repo security events

### DIFF
--- a/.github/workflows/prod-docker-build-push.yml
+++ b/.github/workflows/prod-docker-build-push.yml
@@ -12,7 +12,8 @@ env:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
+  security-events: write
 
 jobs:
   push-production:


### PR DESCRIPTION
# Summary
Update the prod Docker build/push workflow so that the newly generated SBOM can be written to the repo's security events.

# Related
- Closes https://github.com/cds-snc/platform-forms-client/issues/4289