### PR TITLE
chore: bump packages for modules outside of API code to latest version

### DIFF
--- a/examples/nodejs/package-lock.json
+++ b/examples/nodejs/package-lock.json
@@ -10,17 +10,17 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",
-        "jose": "^5.9.2"
+        "jose": "^5.9.3"
       },
       "devDependencies": {
-        "@types/node": "^22.1.0",
+        "@types/node": "^22.7.4",
         "typescript": "^5.6.2"
       }
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.2.tgz",
-      "integrity": "sha512-ILI2xx/I57b20sd7rHZvgiiQrmp2mcotwsAH+5ajbpFQbrYVQdNHYlQhoA5cFb78CgtBOxtC05TeA+mcgkuCqQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.3.tgz",
+      "integrity": "sha512-egLIoYSpcd+QUF+UHgobt5YzI2Pkw/H39ou9suW687MY6PmCwPmkNV/4TNjn1p2tX5xO3j0d0sq5hiYE24bSlg==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -10,10 +10,10 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.7.7",
-    "jose": "^5.9.2"
+    "jose": "^5.9.3"
   },
   "devDependencies": {
-    "@types/node": "^22.1.0",
+    "@types/node": "^22.7.4",
     "typescript": "^5.6.2"
   }
 }

--- a/utils/responseRetriever/package.json
+++ b/utils/responseRetriever/package.json
@@ -10,14 +10,13 @@
   "keywords": [],
   "author": "Bryan Robitaille",
   "dependencies": {
-    "@types/node": "^20.10.5",
-    "axios": "^1.6.3",
-    "dotenv": "^16.3.1",
-    "jose": "^5.4.0",
+    "@types/node": "^22.7.4",
+    "axios": "^1.7.7",
+    "dotenv": "^16.4.5",
+    "jose": "^5.9.3",
     "pino": "^9.4.0",
-    "tslib": "^2.6.2",
-    "tsx": "^4.7.0",
-    "typescript": "^5.3.3"
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.2"
   },
   "devDependencies": {
     "pino-pretty": "^11.2.2"

--- a/utils/responseRetriever/pnpm-lock.yaml
+++ b/utils/responseRetriever/pnpm-lock.yaml
@@ -9,29 +9,26 @@ importers:
   .:
     dependencies:
       '@types/node':
-        specifier: ^20.10.5
-        version: 20.16.4
+        specifier: ^22.7.4
+        version: 22.7.4
       axios:
-        specifier: ^1.6.3
+        specifier: ^1.7.7
         version: 1.7.7
       dotenv:
-        specifier: ^16.3.1
+        specifier: ^16.4.5
         version: 16.4.5
       jose:
-        specifier: ^5.4.0
-        version: 5.8.0
+        specifier: ^5.9.3
+        version: 5.9.3
       pino:
         specifier: ^9.4.0
         version: 9.4.0
-      tslib:
-        specifier: ^2.6.2
-        version: 2.7.0
       tsx:
-        specifier: ^4.7.0
-        version: 4.19.0
+        specifier: ^4.19.1
+        version: 4.19.1
       typescript:
-        specifier: ^5.3.3
-        version: 5.5.4
+        specifier: ^5.6.2
+        version: 5.6.2
     devDependencies:
       pino-pretty:
         specifier: ^11.2.2
@@ -183,8 +180,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@types/node@20.16.4':
-    resolution: {integrity: sha512-ioyQ1zK9aGEomJ45zz8S8IdzElyxhvP1RVWnPrXDf6wFaUb+kk1tEcVVJkF7RPGM0VWI7cp5U57oCPIn5iN1qg==}
+  '@types/node@22.7.4':
+    resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -253,6 +250,7 @@ packages:
   follow-redirects@1.15.8:
     resolution: {integrity: sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==}
     engines: {node: '>=4.0'}
+    deprecated: Browser detection issues fixed in v1.15.9
     peerDependencies:
       debug: '*'
     peerDependenciesMeta:
@@ -277,8 +275,8 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  jose@5.8.0:
-    resolution: {integrity: sha512-E7CqYpL/t7MMnfGnK/eg416OsFCVUrU/Y3Vwe7QjKhu/BkS1Ms455+2xsqZQVN57/U2MHMBvEb5SrmAZWAIntA==}
+  jose@5.9.3:
+    resolution: {integrity: sha512-egLIoYSpcd+QUF+UHgobt5YzI2Pkw/H39ou9suW687MY6PmCwPmkNV/4TNjn1p2tX5xO3j0d0sq5hiYE24bSlg==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -370,16 +368,13 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
-  tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
-
-  tsx@4.19.0:
-    resolution: {integrity: sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==}
+  tsx@4.19.1:
+    resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -463,7 +458,7 @@ snapshots:
   '@esbuild/win32-x64@0.23.1':
     optional: true
 
-  '@types/node@20.16.4':
+  '@types/node@22.7.4':
     dependencies:
       undici-types: 6.19.8
 
@@ -562,7 +557,7 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  jose@5.8.0: {}
+  jose@5.9.3: {}
 
   joycon@3.1.1: {}
 
@@ -665,16 +660,14 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
-  tslib@2.7.0: {}
-
-  tsx@4.19.0:
+  tsx@4.19.1:
     dependencies:
       esbuild: 0.23.1
       get-tsconfig: 4.8.0
     optionalDependencies:
       fsevents: 2.3.3
 
-  typescript@5.5.4: {}
+  typescript@5.6.2: {}
 
   undici-types@6.19.8: {}
 


### PR DESCRIPTION
# Summary | Résumé

- Follow-up PR for https://github.com/cds-snc/forms-api/pull/82 to bump packages in modules outside of API code.