### PR TITLE
feat: API integration examples use formId from API private key file

### DIFF
--- a/examples/bash/.env.staging
+++ b/examples/bash/.env.staging
@@ -7,3 +7,5 @@ if [ -z "$json_key_file" ]; then
   echo "Private key file not found.  Please make sure it is in the script directory and ends with '_private_api_key.json'"
   exit 1
 fi
+
+form_id="$(jq -r '.formId' "$json_key_file")"

--- a/examples/bash/README.md
+++ b/examples/bash/README.md
@@ -16,16 +16,16 @@ Put the private key file you have generated through the GCForms web application 
 The scripts are meant to be run in order to give you an idea of how the request flow works.
 
 1. `get_access_token.sh`: generates a JSON web token and request an access key.
-2. `get_new_form_submissions.sh`: retrieves a list of submissions for your form.  The form ID is the first part of your private key's filename.
-3. `get_form_submission.sh`: retrieves an encrypted form response.  Use one of the form submission name properties from the new form submissions. 
-4. `decrypt_form_submission.sh`: decrypt a retrieved form submission.  The easiest to test this is as follows:
+2. `get_new_form_submissions.sh`: retrieves a list of submissions for your form.
+3. `get_form_submission.sh`: retrieves an encrypted form response. Use one of the form submission name properties from the new form submissions. 
+4. `decrypt_form_submission.sh`: decrypt a retrieved form submission. The easiest to test this is as follows:
 ```sh
 # Capture the encrypted response in a file
 ./get_form_submission.sh > form_response.json
 ./decrypt_form_submission.sh
 ```
-5. `validate_form_submission.sh`: checks that the form submission has not been altered during transit.  The 'answers' and 'checksum' values are part of the decrypted form response.
-6. `confirm_form_submission.sh`: confirms receipt of a form submission.  The confirmation code is included with the decrypted form response.
+5. `validate_form_submission.sh`: checks that the form submission has not been altered during transit. The 'answers' and 'checksum' values are part of the decrypted form response.
+6. `confirm_form_submission.sh`: confirms receipt of a form submission. The confirmation code is included with the decrypted form response.
 7. `get_form_template.sh`: optionally, retrieve the form template used by GC Forms to build and display the form to users.
 
 To report a problem with a form submission you have downloaded you can use `report_problem_with_form_submission.sh`.

--- a/examples/bash/confirm_form_submission.sh
+++ b/examples/bash/confirm_form_submission.sh
@@ -7,19 +7,17 @@ source "$script_dir/.env.staging"
 
 # Confirm the form submission
 confirm_form_submission() {
-  local form_id="$1"
-  local access_token="$2"
-  local submission_name="$3"
-  local confirmation_code="$4"
+  local access_token="$1"
+  local submission_name="$2"
+  local confirmation_code="$3"
 
   curl -sX PUT "$api_url/forms/$form_id/submission/$submission_name/confirm/$confirmation_code" \
     -H "Authorization: Bearer $access_token" \
     -H "Content-Type: application/json"
 }
 
-read -p "Enter the form ID: " form_id
 read -p "Enter the form submission name: " submission_name
 read -p "Enter the form submission confirmation code: " confirmation_code
 read -p "Enter your access token: " access_token
 
-confirm_form_submission "$form_id" "$access_token" "$submission_name" "$confirmation_code"
+confirm_form_submission "$access_token" "$submission_name" "$confirmation_code"

--- a/examples/bash/get_form_submission.sh
+++ b/examples/bash/get_form_submission.sh
@@ -7,17 +7,15 @@ source "$script_dir/.env.staging"
 
 # Retrieve the encrypted form submission
 get_form_response() {
-  local form_id="$1"
-  local access_token="$2"
-  local submission_name="$3"
+  local access_token="$1"
+  local submission_name="$2"
 
   curl -sX GET "${api_url}/forms/${form_id}/submission/${submission_name}" \
     -H "Authorization: Bearer $access_token" \
     -H "Content-Type: application/json"
 }
 
-read -p "Enter the form ID: " form_id
 read -p "Enter the form submission name: " submission_name
 read -p "Enter your access token: " access_token
 
-get_form_response "$form_id" "$access_token" "$submission_name"
+get_form_response "$access_token" "$submission_name"

--- a/examples/bash/get_form_template.sh
+++ b/examples/bash/get_form_template.sh
@@ -7,15 +7,13 @@ source "$script_dir/.env.staging"
 
 # Retrieve the form template
 get_form_template() {
-  local form_id="$1"
-  local access_token="$2"
+  local access_token="$1"
 
   curl -sX GET "${api_url}/forms/${form_id}/template" \
     -H "Authorization: Bearer $access_token" \
     -H "Content-Type: application/json"
 }
 
-read -p "Enter the form ID: " form_id
 read -p "Enter your access token: " access_token
 
-get_form_template "$form_id" "$access_token"
+get_form_template "$access_token"

--- a/examples/bash/get_new_form_submissions.sh
+++ b/examples/bash/get_new_form_submissions.sh
@@ -7,15 +7,13 @@ source "$script_dir/.env.staging"
 
 # Retrieve the new form submission names
 get_new_form_submissions() {
-  local form_id="$1"
-  local access_token="$2"
+  local access_token="$1"
 
   curl -s "$api_url/forms/$form_id/submission/new" \
     -H "Authorization: Bearer $access_token" \
     -H "Content-Type: application/json"
 }
 
-read -p "Enter the form ID: " form_id
 read -p "Enter your access token: " access_token
 
-get_new_form_submissions "$form_id" "$access_token"
+get_new_form_submissions "$access_token"

--- a/examples/bash/report_problem_with_form_submission.sh
+++ b/examples/bash/report_problem_with_form_submission.sh
@@ -7,12 +7,11 @@ source "$script_dir/.env.staging"
 
 # Report problem with form submission
 report_problem_with_form_submission() {
-  local form_id="$1"
-  local submission_name="$2"
-  local contact_email="$3"
-  local description="$4"
-  local preferred_language="$5"
-  local access_token="$6"
+  local submission_name="$1"
+  local contact_email="$2"
+  local description="$3"
+  local preferred_language="$4"
+  local access_token="$5"
 
   curl -sX POST "$api_url/forms/$form_id/submission/$submission_name/problem" \
     -H "Authorization: Bearer $access_token" \
@@ -26,11 +25,10 @@ report_problem_with_form_submission() {
 EOF
 }
 
-read -p "Enter the form ID: " form_id
 read -p "Enter the form submission name: " submission_name
 read -p "Enter a contact email address: " contact_email
 read -p "Enter a description of the problem (10 characters minimum): " description
 read -p "Enter your preferred communication language (either 'en' or 'fr'): " preferred_language
 read -p "Enter your access token: " access_token
 
-report_problem_with_form_submission "$form_id" "$submission_name" "$contact_email" "$description" "$preferred_language" "$access_token"
+report_problem_with_form_submission "$submission_name" "$contact_email" "$description" "$preferred_language" "$access_token"

--- a/examples/dotnet/DataStructures.cs
+++ b/examples/dotnet/DataStructures.cs
@@ -10,6 +10,8 @@ namespace dotnet
     public required string key { get; set; }
 
     public required string userId { get; set; }
+
+    public required string formId { get; set; }
   }
 
   public struct NewFormSubmission

--- a/examples/dotnet/GCFormsApiClient.cs
+++ b/examples/dotnet/GCFormsApiClient.cs
@@ -7,10 +7,12 @@ namespace dotnet
 {
   public class GCFormsApiClient
   {
+    private readonly string formId;
     private readonly HttpClient httpClient;
 
-    public GCFormsApiClient(string apiUrl, string accessToken)
+    public GCFormsApiClient(string formId, string apiUrl, string accessToken)
     {
+      this.formId = formId;
       this.httpClient = new HttpClient()
       {
         BaseAddress = new Uri(apiUrl),
@@ -23,13 +25,13 @@ namespace dotnet
       this.httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
     }
 
-    public Task<object> GetFormTemplate(string formId)
+    public Task<object> GetFormTemplate()
     {
       try
       {
         return this
           .httpClient
-          .GetAsync($"/forms/{formId}/template")
+          .GetAsync($"/forms/{this.formId}/template")
           .Result
           .EnsureSuccessStatusCode()
           .Content
@@ -41,13 +43,13 @@ namespace dotnet
       }
     }
 
-    public Task<List<NewFormSubmission>> GetNewFormSubmissions(string formId)
+    public Task<List<NewFormSubmission>> GetNewFormSubmissions()
     {
       try
       {
         return this
           .httpClient
-          .GetAsync($"/forms/{formId}/submission/new")
+          .GetAsync($"/forms/{this.formId}/submission/new")
           .Result
           .EnsureSuccessStatusCode()
           .Content
@@ -59,13 +61,13 @@ namespace dotnet
       }
     }
 
-    public Task<EncryptedFormSubmission> GetFormSubmission(string formId, string submissionName)
+    public Task<EncryptedFormSubmission> GetFormSubmission(string submissionName)
     {
       try
       {
         return this
           .httpClient
-          .GetAsync($"/forms/{formId}/submission/{submissionName}")
+          .GetAsync($"/forms/{this.formId}/submission/{submissionName}")
           .Result
           .EnsureSuccessStatusCode()
           .Content
@@ -77,13 +79,13 @@ namespace dotnet
       }
     }
 
-    public async Task ConfirmFormSubmission(string formId, string submissionName, string confirmationCode)
+    public async Task ConfirmFormSubmission(string submissionName, string confirmationCode)
     {
       try
       {
         HttpResponseMessage response = await this
           .httpClient
-          .PutAsync($"/forms/{formId}/submission/{submissionName}/confirm/{confirmationCode}", null);
+          .PutAsync($"/forms/{this.formId}/submission/{submissionName}/confirm/{confirmationCode}", null);
 
         response.EnsureSuccessStatusCode();
       }
@@ -93,14 +95,14 @@ namespace dotnet
       }
     }
 
-    public async Task ReportProblemWithFormSubmission(string formId, string submissionName, FormSubmissionProblem problem)
+    public async Task ReportProblemWithFormSubmission(string submissionName, FormSubmissionProblem problem)
     {
       try
       {
         HttpResponseMessage response = await this
           .httpClient
           .PostAsync(
-            $"/forms/{formId}/submission/{submissionName}/problem",
+            $"/forms/{this.formId}/submission/{submissionName}/problem",
             new StringContent(JsonSerializer.Serialize(problem), Encoding.UTF8, "application/json")
           );
 

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -38,25 +38,21 @@ Selection (1):
             break;
           case "2":
             {
-              Console.WriteLine("\nForm ID to retrieve responses for:");
-
-              string formId = Console.ReadLine();
-
               Console.WriteLine("\nGenerating access token...");
 
               string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
 
-              GCFormsApiClient apiClient = new(GCFORMS_API_URL, accessToken);
+              GCFormsApiClient apiClient = new(privateApiKey.formId, GCFORMS_API_URL, accessToken);
 
               Console.WriteLine("\nRetrieving form template...\n");
 
-              object formTemplate = await apiClient.GetFormTemplate(formId);
+              object formTemplate = await apiClient.GetFormTemplate();
 
               Console.WriteLine(formTemplate);
 
               Console.WriteLine("\nRetrieving new form submissions...");
 
-              List<NewFormSubmission> newFormSubmissions = await apiClient.GetNewFormSubmissions(formId);
+              List<NewFormSubmission> newFormSubmissions = await apiClient.GetNewFormSubmissions();
 
               if (newFormSubmissions.Count > 0)
               {
@@ -71,7 +67,7 @@ Selection (1):
 
                   Console.WriteLine("Retrieving encrypted submission...");
 
-                  EncryptedFormSubmission encryptedSubmission = await apiClient.GetFormSubmission(formId, newFormSubmission.name);
+                  EncryptedFormSubmission encryptedSubmission = await apiClient.GetFormSubmission(newFormSubmission.name);
 
                   Console.WriteLine("\nEncrypted submission:");
                   Console.WriteLine(encryptedSubmission.encryptedResponses);
@@ -93,7 +89,7 @@ Selection (1):
 
                   Console.WriteLine("\nConfirming submission...");
 
-                  await apiClient.ConfirmFormSubmission(formId, newFormSubmission.name, formSubmission.confirmationCode);
+                  await apiClient.ConfirmFormSubmission(newFormSubmission.name, formSubmission.confirmationCode);
 
                   Console.WriteLine("\nSubmission confirmed");
 
@@ -109,10 +105,6 @@ Selection (1):
             break;
           case "3":
             {
-              Console.WriteLine("\nForm ID associated to the submission you want to report:");
-
-              string formId = Console.ReadLine();
-
               Console.WriteLine("\nSubmission name:");
 
               string submissionName = Console.ReadLine();
@@ -133,7 +125,7 @@ Selection (1):
 
               string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
 
-              GCFormsApiClient apiClient = new(GCFORMS_API_URL, accessToken);
+              GCFormsApiClient apiClient = new(privateApiKey.formId, GCFORMS_API_URL, accessToken);
 
               Console.WriteLine("\nReporting form submission...");
 
@@ -144,7 +136,7 @@ Selection (1):
                 preferredLanguage = preferredLanguage
               };
 
-              await apiClient.ReportProblemWithFormSubmission(formId, submissionName, problem);
+              await apiClient.ReportProblemWithFormSubmission(submissionName, problem);
 
               Console.WriteLine($"\nSubmission has been reported");
             }

--- a/examples/nodejs/gcFormsApiClient.ts
+++ b/examples/nodejs/gcFormsApiClient.ts
@@ -6,9 +6,11 @@ import type {
 } from "./types.js";
 
 export class GCFormsApiClient {
+  private formId: string;
   private httpClient: AxiosInstance;
 
-  public constructor(apiUrl: string, accessToken: string) {
+  public constructor(formId: string, apiUrl: string, accessToken: string) {
+    this.formId = formId;
     this.httpClient = axios.create({
       baseURL: apiUrl,
       timeout: 3000,
@@ -16,18 +18,18 @@ export class GCFormsApiClient {
     });
   }
 
-  public getFormTemplate(formId: string): Promise<Record<string, unknown>> {
+  public getFormTemplate(): Promise<Record<string, unknown>> {
     return this.httpClient
-      .get<Record<string, unknown>>(`/forms/${formId}/template`)
+      .get<Record<string, unknown>>(`/forms/${this.formId}/template`)
       .then((response) => response.data)
       .catch((error) => {
         throw new Error("Failed to retrieve form template", { cause: error });
       });
   }
 
-  public getNewFormSubmissions(formId: string): Promise<NewFormSubmission[]> {
+  public getNewFormSubmissions(): Promise<NewFormSubmission[]> {
     return this.httpClient
-      .get<NewFormSubmission[]>(`/forms/${formId}/submission/new`)
+      .get<NewFormSubmission[]>(`/forms/${this.formId}/submission/new`)
       .then((response) => response.data)
       .catch((error) => {
         throw new Error("Failed to retrieve new form submissions", {
@@ -37,12 +39,11 @@ export class GCFormsApiClient {
   }
 
   public getFormSubmission(
-    formId: string,
     submissionName: string,
   ): Promise<EncryptedFormSubmission> {
     return this.httpClient
       .get<EncryptedFormSubmission>(
-        `/forms/${formId}/submission/${submissionName}`,
+        `/forms/${this.formId}/submission/${submissionName}`,
       )
       .then((response) => response.data)
       .catch((error) => {
@@ -51,13 +52,12 @@ export class GCFormsApiClient {
   }
 
   public confirmFormSubmission(
-    formId: string,
     submissionName: string,
     confirmationCode: string,
   ): Promise<void> {
     return this.httpClient
       .put<void>(
-        `/forms/${formId}/submission/${submissionName}/confirm/${confirmationCode}`,
+        `/forms/${this.formId}/submission/${submissionName}/confirm/${confirmationCode}`,
       )
       .then(() => Promise.resolve())
       .catch((error) => {
@@ -66,13 +66,12 @@ export class GCFormsApiClient {
   }
 
   public reportProblemWithFormSubmission(
-    formId: string,
     submissionName: string,
     problem: FormSubmissionProblem,
   ): Promise<void> {
     return this.httpClient
       .post<void>(
-        `/forms/${formId}/submission/${submissionName}/problem`,
+        `/forms/${this.formId}/submission/${submissionName}/problem`,
         problem,
         {
           headers: {

--- a/examples/nodejs/index.ts
+++ b/examples/nodejs/index.ts
@@ -28,10 +28,6 @@ Selection (1):
 
     switch (menuSelection) {
       case "2": {
-        const formId = await requestUserInput(
-          "\nForm ID to retrieve responses for:\n",
-        );
-
         console.info("\nGenerating access token...");
 
         const accessToken = await generateAccessToken(
@@ -40,18 +36,21 @@ Selection (1):
           privateApiKey,
         );
 
-        const apiClient = new GCFormsApiClient(GCFORMS_API_URL, accessToken);
+        const apiClient = new GCFormsApiClient(
+          privateApiKey.formId,
+          GCFORMS_API_URL,
+          accessToken,
+        );
 
         console.info("\nRetrieving form template...\n");
 
-        const formTemplate = await apiClient.getFormTemplate(formId);
+        const formTemplate = await apiClient.getFormTemplate();
 
         console.info(formTemplate);
 
         console.info("\nRetrieving new form submissions...");
 
-        const newFormSubmissions =
-          await apiClient.getNewFormSubmissions(formId);
+        const newFormSubmissions = await apiClient.getNewFormSubmissions();
 
         if (newFormSubmissions.length > 0) {
           console.info("\nNew form submissions:");
@@ -67,7 +66,6 @@ Selection (1):
             console.info("Retrieving encrypted submission...");
 
             const encryptedSubmission = await apiClient.getFormSubmission(
-              formId,
               newFormSubmission.name,
             );
 
@@ -102,7 +100,6 @@ Selection (1):
             console.info("\nConfirming submission...");
 
             await apiClient.confirmFormSubmission(
-              formId,
               newFormSubmission.name,
               formSubmission.confirmationCode,
             );
@@ -119,10 +116,6 @@ Selection (1):
         break;
       }
       case "3": {
-        const formId = await requestUserInput(
-          "\nForm ID associated to the submission you want to report:\n",
-        );
-
         const submissionName = await requestUserInput("\nSubmission name:\n");
 
         const contactEmail = await requestUserInput(
@@ -145,7 +138,11 @@ Selection (1):
           privateApiKey,
         );
 
-        const apiClient = new GCFormsApiClient(GCFORMS_API_URL, accessToken);
+        const apiClient = new GCFormsApiClient(
+          privateApiKey.formId,
+          GCFORMS_API_URL,
+          accessToken,
+        );
 
         console.info("\nReporting form submission...");
 
@@ -156,7 +153,6 @@ Selection (1):
         };
 
         await apiClient.reportProblemWithFormSubmission(
-          formId,
           submissionName,
           problem,
         );

--- a/examples/nodejs/types.d.ts
+++ b/examples/nodejs/types.d.ts
@@ -2,6 +2,7 @@ export type PrivateApiKey = {
   keyId: string;
   key: string;
   userId: string;
+  formId: string;
 };
 
 export type NewFormSubmission = {

--- a/examples/python/data_structures.py
+++ b/examples/python/data_structures.py
@@ -7,6 +7,7 @@ class PrivateApiKey:
     key_id: str
     key: str
     user_id: str
+    form_id: str
 
     @staticmethod
     def from_json(json_object: dict) -> "PrivateApiKey":
@@ -14,6 +15,7 @@ class PrivateApiKey:
             key_id=json_object["keyId"],
             key=json_object["key"],
             user_id=json_object["userId"],
+            form_id=json_object["formId"],
         )
 
 

--- a/examples/python/gc_forms_api_client.py
+++ b/examples/python/gc_forms_api_client.py
@@ -8,37 +8,37 @@ from data_structures import (
 
 
 class GCFormsApiClient:
+    form_id: str
     httpClient: httpx.Client
 
-    def __init__(self, api_url: str, access_token: str):
+    def __init__(self, form_id: str, api_url: str, access_token: str):
+        self.form_id = form_id
         self.httpClient = httpx.Client(
             base_url=api_url,
             timeout=3,
             headers={"Authorization": f"Bearer {access_token}"},
         )
 
-    def get_form_template(self, form_id: str) -> dict:
+    def get_form_template(self) -> dict:
         try:
-            response = self.httpClient.get(f"/forms/{form_id}/template")
+            response = self.httpClient.get(f"/forms/{self.form_id}/template")
             response.raise_for_status()
             return dict(response.json())
         except Exception as exception:
             raise Exception("Failed to retrieve form template") from exception
 
-    def get_new_form_submissions(self, form_id: str) -> List[NewFormSubmission]:
+    def get_new_form_submissions(self) -> List[NewFormSubmission]:
         try:
-            response = self.httpClient.get(f"/forms/{form_id}/submission/new")
+            response = self.httpClient.get(f"/forms/{self.form_id}/submission/new")
             response.raise_for_status()
             return [NewFormSubmission.from_json(item) for item in response.json()]
         except Exception as exception:
             raise Exception("Failed to retrieve new form submissions") from exception
 
-    def get_form_submission(
-        self, form_id: str, submission_name: str
-    ) -> EncryptedFormSubmission:
+    def get_form_submission(self, submission_name: str) -> EncryptedFormSubmission:
         try:
             response = self.httpClient.get(
-                f"/forms/{form_id}/submission/{submission_name}"
+                f"/forms/{self.form_id}/submission/{submission_name}"
             )
             response.raise_for_status()
             return EncryptedFormSubmission.from_json(response.json())
@@ -46,22 +46,22 @@ class GCFormsApiClient:
             raise Exception("Failed to retrieve form submission") from exception
 
     def confirm_form_submission(
-        self, form_id: str, submission_name: str, confirmation_code: str
+        self, submission_name: str, confirmation_code: str
     ) -> None:
         try:
             response = self.httpClient.put(
-                f"/forms/{form_id}/submission/{submission_name}/confirm/{confirmation_code}"
+                f"/forms/{self.form_id}/submission/{submission_name}/confirm/{confirmation_code}"
             )
             response.raise_for_status()
         except Exception as exception:
             raise Exception("Failed to confirm form submission") from exception
 
     def report_problem_with_form_submission(
-        self, form_id: str, submission_name: str, problem: FormSubmissionProblem
+        self, submission_name: str, problem: FormSubmissionProblem
     ) -> None:
         try:
             response = self.httpClient.post(
-                f"/forms/{form_id}/submission/{submission_name}/problem",
+                f"/forms/{self.form_id}/submission/{submission_name}/problem",
                 json=problem.to_json(),
             )
             response.raise_for_status()

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -15,34 +15,35 @@ def main() -> None:
     private_api_key = load_private_api_key()
 
     menu_selection = input(
-    """
+        """
 I want to:
 (1) Generate and display an access token
 (2) Retrieve, decrypt and confirm form submissions
 (3) Report a problem with a form submission
 Selection (1):
-""")
+"""
+    )
 
     if menu_selection == "2":
-        form_id = input("\nForm ID to retrieve responses for:\n")
-
         print("\nGenerating access token...")
 
         access_token = AccessTokenGenerator.generate(
             IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
         )
 
-        api_client = GCFormsApiClient(GCFORMS_API_URL, access_token)
+        api_client = GCFormsApiClient(
+            private_api_key.form_id, GCFORMS_API_URL, access_token
+        )
 
         print("\nRetrieving form template...\n")
 
-        form_template = api_client.get_form_template(form_id)
+        form_template = api_client.get_form_template()
 
         print(form_template)
 
         print("\nRetrieving new form submissions...")
 
-        new_form_submissions = api_client.get_new_form_submissions(form_id)
+        new_form_submissions = api_client.get_new_form_submissions()
 
         if len(new_form_submissions) > 0:
             print("\nNew form submissions:")
@@ -57,7 +58,7 @@ Selection (1):
                 print("Retrieving encrypted submission...")
 
                 encrypted_submission = api_client.get_form_submission(
-                    form_id, new_form_submission.name
+                    new_form_submission.name
                 )
 
                 print("\nEncrypted submission:")
@@ -78,8 +79,8 @@ Selection (1):
 
                 print("\nVerifying submission integrity...")
 
-                integrity_verification_result = (
-                    FormSubmissionVerifier.verify_integrity(form_submission.answers, form_submission.checksum)
+                integrity_verification_result = FormSubmissionVerifier.verify_integrity(
+                    form_submission.answers, form_submission.checksum
                 )
 
                 print(
@@ -88,7 +89,9 @@ Selection (1):
 
                 print("\nConfirming submission...")
 
-                api_client.confirm_form_submission(form_id, new_form_submission.name, form_submission.confirmation_code)
+                api_client.confirm_form_submission(
+                    new_form_submission.name, form_submission.confirmation_code
+                )
 
                 print("\nSubmission confirmed")
 
@@ -98,15 +101,15 @@ Selection (1):
         else:
             print("\nCould not find any new form submission!")
     elif menu_selection == "3":
-        form_id = input("\nForm ID associated to the submission you want to report:\n")
-
         submission_name = input("\nSubmission name:\n")
 
         contact_email = input("\nContact email address:\n")
 
         description = input("\nProblem description (10 characters minimum):\n")
 
-        preferred_language = input("\nPreferred communication language (either 'en' or 'fr'):\n")
+        preferred_language = input(
+            "\nPreferred communication language (either 'en' or 'fr'):\n"
+        )
 
         print("\nGenerating access token...")
 
@@ -114,13 +117,15 @@ Selection (1):
             IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
         )
 
-        api_client = GCFormsApiClient(GCFORMS_API_URL, access_token)
+        api_client = GCFormsApiClient(
+            private_api_key.form_id, GCFORMS_API_URL, access_token
+        )
 
         print("\nReporting form submission...")
 
         problem = FormSubmissionProblem(contact_email, description, preferred_language)
 
-        api_client.report_problem_with_form_submission(form_id, submission_name, problem)
+        api_client.report_problem_with_form_submission(submission_name, problem)
 
         print("\nSubmission has been reported")
     else:


### PR DESCRIPTION
# Summary | Résumé

- API integration examples use `formId` from API private key file instead of asking for it