### PR TITLE
fix: authentication middleware tries to send JSON message as part of the response after the HTTP response has completed

### DIFF
--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -16,12 +16,10 @@ export async function authenticationMiddleware(
     const formId = request.params.formId;
 
     if (!accessToken) {
-      // Authorization header is missing
-      response
-        .sendStatus(401)
-        .json({ error: "Authorization header is missing" });
+      response.status(401).json({ error: "Authorization header is missing" });
       return;
     }
+
     const verifiedAccessToken = await verifyAccessToken(accessToken, formId);
 
     request.serviceUserId = verifiedAccessToken.serviceUserId;

--- a/test/middleware/authentication.test.ts
+++ b/test/middleware/authentication.test.ts
@@ -54,7 +54,10 @@ describe("authenticationMiddleware should", () => {
     await authenticationMiddleware(requestMock, responseMock, nextMock);
 
     expect(nextMock).not.toHaveBeenCalled();
-    expect(responseMock.sendStatus).toHaveBeenCalledWith(401);
+    expect(responseMock.status).toHaveBeenCalledWith(401);
+    expect(responseMock.json).toHaveBeenCalledWith({
+      error: "Authorization header is missing",
+    });
   });
 
   it("respond with error when the authorization header value is invalid", async () => {


### PR DESCRIPTION
# Summary | Résumé

- Found a bug when looking at some of our API logs. Authentication middleware tries to send a JSON payload but the HTTP response was already completed.