### PR TITLE
refactor: replace use of Status with new Status#CreatedAt attribute when requesting Vault items

### DIFF
--- a/src/lib/vault/confirmFormSubmission.ts
+++ b/src/lib/vault/confirmFormSubmission.ts
@@ -43,13 +43,11 @@ export async function confirmFormSubmission(
           NAME_OR_CONF: `NAME#${submissionName}`,
         },
         UpdateExpression:
-          "SET #status = :status, #statusCreatedAtKey = :statusCreatedAtValue, ConfirmTimestamp = :confirmTimestamp, RemovalDate = :removalDate",
+          "SET #statusCreatedAtKey = :statusCreatedAtValue, ConfirmTimestamp = :confirmTimestamp, RemovalDate = :removalDate",
         ExpressionAttributeNames: {
-          "#status": "Status",
           "#statusCreatedAtKey": "Status#CreatedAt",
         },
         ExpressionAttributeValues: {
-          ":status": "Confirmed",
           ":statusCreatedAtValue": `Confirmed#${formSubmission.createdAt}`,
           ":confirmTimestamp": confirmationTimestamp,
           ":removalDate": removalDate,

--- a/src/lib/vault/getFormSubmission.ts
+++ b/src/lib/vault/getFormSubmission.ts
@@ -1,7 +1,7 @@
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
-import type {
-  FormSubmission,
+import {
+  type FormSubmission,
   FormSubmissionStatus,
 } from "@lib/vault/types/formSubmission.js";
 import { logMessage } from "@lib/logging/logger.js";
@@ -17,9 +17,9 @@ export async function getFormSubmission(
           TableName: "Vault",
           Key: { FormID: formId, NAME_OR_CONF: `NAME#${submissionName}` },
           ProjectionExpression:
-            "CreatedAt,#status,ConfirmationCode,FormSubmission,FormSubmissionHash",
+            "CreatedAt,#statusCreatedAtKey,ConfirmationCode,FormSubmission,FormSubmissionHash",
           ExpressionAttributeNames: {
-            "#status": "Status",
+            "#statusCreatedAtKey": "Status#CreatedAt",
           },
         }),
       );
@@ -44,9 +44,32 @@ function formSubmissionFromDynamoDbResponse(
 ): FormSubmission {
   return {
     createdAt: response.CreatedAt as number,
-    status: response.Status as FormSubmissionStatus,
+    status: formSubmissionStatusFromStatusCreatedAt(
+      response["Status#CreatedAt"] as string,
+    ),
     confirmationCode: response.ConfirmationCode as string,
     answers: response.FormSubmission as string,
     checksum: response.FormSubmissionHash as string,
   };
+}
+
+function formSubmissionStatusFromStatusCreatedAt(
+  statusCreatedAtValue: string,
+): FormSubmissionStatus {
+  const status = statusCreatedAtValue.split("#")[0];
+
+  switch (status) {
+    case "New":
+      return FormSubmissionStatus.New;
+    case "Downloaded":
+      return FormSubmissionStatus.Downloaded;
+    case "Confirmed":
+      return FormSubmissionStatus.Confirmed;
+    case "Problem":
+      return FormSubmissionStatus.Problem;
+    default:
+      throw new Error(
+        `Unsupported Status#CreatedAt value. Value = ${statusCreatedAtValue}.`,
+      );
+  }
 }

--- a/src/lib/vault/reportProblemWithFormSubmission.ts
+++ b/src/lib/vault/reportProblemWithFormSubmission.ts
@@ -31,13 +31,11 @@ export async function reportProblemWithFormSubmission(
           NAME_OR_CONF: `NAME#${submissionName}`,
         },
         UpdateExpression:
-          "SET #status = :status, #statusCreatedAtKey = :statusCreatedAtValue, ProblemTimestamp = :problemTimestamp REMOVE RemovalDate",
+          "SET #statusCreatedAtKey = :statusCreatedAtValue, ProblemTimestamp = :problemTimestamp REMOVE RemovalDate",
         ExpressionAttributeNames: {
-          "#status": "Status",
           "#statusCreatedAtKey": "Status#CreatedAt",
         },
         ExpressionAttributeValues: {
-          ":status": "Problem",
           ":statusCreatedAtValue": `Problem#${formSubmission.createdAt}`,
           ":problemTimestamp": Date.now(),
         },

--- a/test/lib/vault/confirmFormSubmission.test.ts
+++ b/test/lib/vault/confirmFormSubmission.test.ts
@@ -45,13 +45,11 @@ describe("confirmFormSubmission should", () => {
     expect(dynamoDbMock.commandCalls(UpdateCommand).length).toEqual(1);
     expect(dynamoDbMock.commandCalls(UpdateCommand)[0].args[0].input).toEqual({
       ExpressionAttributeNames: {
-        "#status": "Status",
         "#statusCreatedAtKey": "Status#CreatedAt",
       },
       ExpressionAttributeValues: {
         ":confirmTimestamp": 1519129853500,
         ":removalDate": 1521721853500,
-        ":status": "Confirmed",
         ":statusCreatedAtValue": "Confirmed#1519129853500",
       },
       Key: {
@@ -60,7 +58,7 @@ describe("confirmFormSubmission should", () => {
       },
       TableName: "Vault",
       UpdateExpression:
-        "SET #status = :status, #statusCreatedAtKey = :statusCreatedAtValue, ConfirmTimestamp = :confirmTimestamp, RemovalDate = :removalDate",
+        "SET #statusCreatedAtKey = :statusCreatedAtValue, ConfirmTimestamp = :confirmTimestamp, RemovalDate = :removalDate",
     });
   });
 

--- a/test/lib/vault/getFormSubmission.test.ts
+++ b/test/lib/vault/getFormSubmission.test.ts
@@ -4,6 +4,7 @@ import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
 import { FormSubmissionStatus } from "@lib/vault/types/formSubmission.js";
 import { logMessage } from "@lib/logging/logger.js";
+import { buildMockedVaultItem } from "test/mocks/dynamodb.js";
 
 const dynamoDbMock = mockClient(DynamoDBDocumentClient);
 
@@ -27,9 +28,7 @@ describe("getFormSubmission should", () => {
 
   it("return a form submission if DynamoDB was able to find it", async () => {
     dynamoDbMock.on(GetCommand).resolvesOnce({
-      Item: {
-        Status: "New",
-      },
+      Item: buildMockedVaultItem("New"),
     });
 
     const formSubmission = await getFormSubmission(

--- a/test/lib/vault/reportProblemWithFormSubmission.test.ts
+++ b/test/lib/vault/reportProblemWithFormSubmission.test.ts
@@ -43,12 +43,10 @@ describe("reportProblemWithFormSubmission should", () => {
     expect(dynamoDbMock.commandCalls(UpdateCommand).length).toEqual(1);
     expect(dynamoDbMock.commandCalls(UpdateCommand)[0].args[0].input).toEqual({
       ExpressionAttributeNames: {
-        "#status": "Status",
         "#statusCreatedAtKey": "Status#CreatedAt",
       },
       ExpressionAttributeValues: {
         ":problemTimestamp": 1519129853500,
-        ":status": "Problem",
         ":statusCreatedAtValue": "Problem#1519129853500",
       },
       Key: {
@@ -57,7 +55,7 @@ describe("reportProblemWithFormSubmission should", () => {
       },
       TableName: "Vault",
       UpdateExpression:
-        "SET #status = :status, #statusCreatedAtKey = :statusCreatedAtValue, ProblemTimestamp = :problemTimestamp REMOVE RemovalDate",
+        "SET #statusCreatedAtKey = :statusCreatedAtValue, ProblemTimestamp = :problemTimestamp REMOVE RemovalDate",
     });
   });
 

--- a/test/mocks/dynamodb.ts
+++ b/test/mocks/dynamodb.ts
@@ -2,9 +2,11 @@ export function buildMockedVaultItem(
   status = "New",
   confirmationCode = "620b203c-9836-4000-bf30-1c3bcc26b834",
 ): Record<string, unknown> {
+  const createdAt = Date.now();
+
   return {
-    CreatedAt: Date.now(),
-    Status: status,
+    CreatedAt: createdAt,
+    "Status#CreatedAt": `${status}#${createdAt}`,
     ConfirmationCode: confirmationCode,
     FormSubmission: '{"1":"Test response"}',
   };


### PR DESCRIPTION
# Summary | Résumé

Part 7 of https://github.com/cds-snc/platform-forms-client/issues/4287

- Replaces any reference to the old `Status` with new `Status#CreatedAt` attribute when requesting Vault items.