### PR TITLE
refactor: rework error logs to reduce noise on Slack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,15 +8,14 @@ ENVIRONMENT_MODE=local
 
 FRESHDESK_API_KEY=""
 
-# (optional) Localstack
-# This will be required if you want your application to target your LocalStack instance
+# (optional) When working with AWS Scratch accounts to direct the AWS SDKs to the right AWS environment
 
-LOCALSTACK_ENDPOINT=http://127.0.0.1:4566
+AWS_PROFILE=development
 
 # (required) Redis
-# The following value is meant to be used when running the API with Localstack
+# When working with AWS Scratch accounts the <REDIS_URL> will be provided by the deployment script once it has completed
 
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://<REDIS_URL>
 
 # (required) Zitadel
 # This is required by the authentication feature but can be left empty if you are disabling it when doing local tests

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,12 +29,6 @@ export const FRESHDESK_API_URL: string = "https://cds-snc.freshdesk.com/api";
 export const FRESHDESK_API_KEY: string =
   loadRequiredEnvVar("FRESHDESK_API_KEY");
 
-// Local configuration
-
-export const LOCALSTACK_ENDPOINT: string | undefined = loadOptionalEnvVar(
-  "LOCALSTACK_ENDPOINT",
-);
-
 // Rate limiting
 
 export const lowRateLimiterConfiguration: TokenBucketConfiguration = {
@@ -61,12 +55,8 @@ export const ZITADEL_APPLICATION_KEY: string = loadRequiredEnvVar(
 
 // Internal function to load environment variables
 
-function loadOptionalEnvVar(envVarName: string): string | undefined {
-  return process.env[envVarName];
-}
-
 function loadRequiredEnvVar(envVarName: string): string {
-  const envVar = loadOptionalEnvVar(envVarName);
+  const envVar = process.env[envVarName];
 
   if (envVar === undefined) {
     throw new Error(`Environment variable ${envVarName} is not defined.`);

--- a/src/lib/formsClient/getPublicKey.ts
+++ b/src/lib/formsClient/getPublicKey.ts
@@ -28,7 +28,7 @@ export const getPublicKey = async (serviceAccountId: string) => {
 
     return publicKey;
   } catch (error) {
-    logMessage.error(
+    logMessage.info(
       error,
       `[formsClient] Failed to retrieve public key. ServiceAccountId: ${serviceAccountId}`,
     );

--- a/src/lib/integration/awsServicesConnector.ts
+++ b/src/lib/integration/awsServicesConnector.ts
@@ -2,16 +2,10 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import { SQSClient } from "@aws-sdk/client-sqs";
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
-import { AWS_REGION, LOCALSTACK_ENDPOINT } from "@config";
+import { AWS_REGION } from "@config";
 
 const globalConfig = {
   region: AWS_REGION,
-};
-
-const localstackConfig = {
-  ...(LOCALSTACK_ENDPOINT && {
-    endpoint: LOCALSTACK_ENDPOINT,
-  }),
 };
 
 export class AwsServicesConnector {
@@ -27,18 +21,15 @@ export class AwsServicesConnector {
     this.dynamodbClient = DynamoDBDocumentClient.from(
       new DynamoDBClient({
         ...globalConfig,
-        ...localstackConfig,
       }),
     );
 
     this.secretsClient = new SecretsManagerClient({
       ...globalConfig,
-      ...localstackConfig,
     });
 
     this.sqsClient = new SQSClient({
       ...globalConfig,
-      ...localstackConfig,
     });
   }
 

--- a/src/lib/integration/databaseConnector.ts
+++ b/src/lib/integration/databaseConnector.ts
@@ -1,20 +1,11 @@
 import pgp, { type IDatabase } from "pg-promise";
 import type { IClient } from "pg-promise/typescript/pg-subset.js";
 import { GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
-import { EnvironmentMode, ENVIRONMENT_MODE } from "@config";
 import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
 import { logMessage } from "@lib/logging/logger.js";
 
 const getConnectionString = async (): Promise<string> => {
   try {
-    if (ENVIRONMENT_MODE === EnvironmentMode.Local) {
-      logMessage.debug(
-        "[database-connector] Using localstack connection string",
-      );
-
-      return "postgres://localstack_postgres:chummy@localhost:4510/forms";
-    }
-
     const response =
       await AwsServicesConnector.getInstance().secretsClient.send(
         new GetSecretValueCommand({

--- a/src/lib/integration/freshdeskConnector.ts
+++ b/src/lib/integration/freshdeskConnector.ts
@@ -44,7 +44,11 @@ export async function createFreshdeskTicket(
       },
     );
   } catch (error) {
-    logMessage.error(error, "Failed to create Freshdesk ticket");
+    logMessage.info(
+      error,
+      "[freshdesk-connector] Failed to create Freshdesk ticket",
+    );
+
     throw error;
   }
 }

--- a/src/lib/integration/redis/redisConnector.ts
+++ b/src/lib/integration/redis/redisConnector.ts
@@ -29,10 +29,10 @@ export class RedisConnector {
         ),
       )
       .on("ready", () =>
-        logMessage.debug("[redis-connector]  Redis client ready!"),
+        logMessage.info("[redis-connector]  Redis client ready!"),
       )
       .on("reconnecting", () =>
-        logMessage.debug("[redis-connector] Redis client reconnecting..."),
+        logMessage.info("[redis-connector] Redis client reconnecting..."),
       );
   }
 

--- a/src/lib/integration/zitadelConnector.ts
+++ b/src/lib/integration/zitadelConnector.ts
@@ -33,7 +33,11 @@ export function introspectAccessToken(
       introspectOpaqueToken(jwtSignedToken, accessToken),
     )
     .catch((error) => {
-      logMessage.error(error, "[zitadel] Failed to introspect access token");
+      logMessage.info(
+        error,
+        "[zitadel-connector] Failed to introspect access token",
+      );
+
       throw new ZitadelConnectionError();
     });
 }

--- a/src/lib/logging/auditLogs.ts
+++ b/src/lib/logging/auditLogs.ts
@@ -55,14 +55,12 @@ export const auditLog = async (
       }),
     );
     if (ENVIRONMENT_MODE === EnvironmentMode.Local) {
-      logMessage.debug(`[Audit-Log] ${auditLogAsJsonString}`);
+      logMessage.debug(`[audit-log] ${auditLogAsJsonString}`);
     }
   } catch (error) {
-    logMessage.error(error, "[logging] Failed to send audit log to AWS SQS");
-
-    // Ensure the audit log is not lost by sending to console
-    logMessage.warn(
-      `[logging] Audit log that failed to be sent: ${auditLogAsJsonString}`,
+    logMessage.error(
+      error,
+      `[audit-log] Failed to send audit log to AWS SQS. Audit log: ${auditLogAsJsonString}.`,
     );
   }
 };

--- a/src/lib/support/notifySupportAboutFormSubmissionProblem.ts
+++ b/src/lib/support/notifySupportAboutFormSubmissionProblem.ts
@@ -26,9 +26,9 @@ export async function notifySupportAboutFormSubmissionProblem(
       preferredLanguage: preferredLanguage,
     });
   } catch (error) {
-    logMessage.error(
+    logMessage.info(
       error,
-      `[support] Failed to notify support about form submission problem. FormId: ${formId} / SubmissionName: ${submissionName} / Contact email: ${contactEmail}`,
+      `[support] Failed to notify support about form submission problem. FormId: ${formId} / SubmissionName: ${submissionName} / Contact email: ${contactEmail} / Description: ${description}`,
     );
 
     throw error;

--- a/src/lib/vault/confirmFormSubmission.ts
+++ b/src/lib/vault/confirmFormSubmission.ts
@@ -55,7 +55,7 @@ export async function confirmFormSubmission(
       }),
     );
   } catch (error) {
-    logMessage.error(
+    logMessage.info(
       error,
       `[dynamodb] Failed to confirm form submission. FormId: ${formId} / SubmissionName: ${submissionName} / ConfirmationCode: ${confirmationCode}`,
     );

--- a/src/lib/vault/getFormSubmission.ts
+++ b/src/lib/vault/getFormSubmission.ts
@@ -30,7 +30,7 @@ export async function getFormSubmission(
 
     return formSubmissionFromDynamoDbResponse(response.Item);
   } catch (error) {
-    logMessage.error(
+    logMessage.info(
       error,
       `[dynamodb] Failed to retrieve form submission. FormId: ${formId} / SubmissionName: ${submissionName}`,
     );

--- a/src/lib/vault/getNewFormSubmissions.ts
+++ b/src/lib/vault/getNewFormSubmissions.ts
@@ -46,7 +46,7 @@ export async function getNewFormSubmissions(
 
     return newFormSubmissions;
   } catch (error) {
-    logMessage.error(
+    logMessage.info(
       error,
       `[dynamodb] Failed to retrieve new form submissions. FormId: ${formId}`,
     );

--- a/src/lib/vault/reportProblemWithFormSubmission.ts
+++ b/src/lib/vault/reportProblemWithFormSubmission.ts
@@ -42,7 +42,7 @@ export async function reportProblemWithFormSubmission(
       }),
     );
   } catch (error) {
-    logMessage.error(
+    logMessage.info(
       error,
       `[dynamodb] Failed to report problem with form submission. FormId: ${formId} / SubmissionName: ${submissionName}`,
     );

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -4,6 +4,7 @@ import {
   AccessTokenExpiredError,
   AccessTokenInvalidError,
   AccessControlError,
+  AccessTokenMalformedError,
 } from "@lib/idp/verifyAccessToken.js";
 
 export async function authenticationMiddleware(
@@ -33,13 +34,14 @@ export async function authenticationMiddleware(
         return;
       }
       case error instanceof AccessTokenInvalidError:
+      case error instanceof AccessTokenMalformedError:
       case error instanceof AccessControlError: {
         response.sendStatus(403);
         return;
       }
       default:
         next(
-          new Error("[middleware] Internal error while authenticating user", {
+          new Error("[middleware][authentication] Internal error", {
             cause: error,
           }),
         );

--- a/src/middleware/globalErrorHandler.ts
+++ b/src/middleware/globalErrorHandler.ts
@@ -8,7 +8,10 @@ export async function globalErrorHandlerMiddleware(
   response: Response,
   _next: NextFunction,
 ): Promise<void> {
-  logMessage.error(error, "Global unhandled error");
+  logMessage.error(
+    error,
+    "[middleware][global-error-handler] Global unhandled error",
+  );
 
   if (request.tokenConsumedOnFormId !== undefined) {
     await refundConsumedToken(request.tokenConsumedOnFormId);

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -30,7 +30,7 @@ export async function rateLimiterMiddleware(
       });
 
       logMessage.info(
-        `[rate-limiter] Form ${formId} consumed all ${consumeTokenResult.bucketStatus.bucketCapacity} tokens. Bucket will be refilled in ${consumeTokenResult.bucketStatus.numberOfMillisecondsBeforeRefill / 1000} seconds`,
+        `[middleware][rate-limiter] Form ${formId} consumed all ${consumeTokenResult.bucketStatus.bucketCapacity} tokens. Bucket will be refilled in ${consumeTokenResult.bucketStatus.numberOfMillisecondsBeforeRefill / 1000} seconds`,
       );
 
       auditLog(
@@ -48,7 +48,7 @@ export async function rateLimiterMiddleware(
     next();
   } catch (error) {
     next(
-      new Error("[middleware] Internal error with rate limiter", {
+      new Error("[middleware][rate-limiter] Internal error", {
         cause: error,
       }),
     );

--- a/src/middleware/requestValidator.ts
+++ b/src/middleware/requestValidator.ts
@@ -34,7 +34,7 @@ export function requestValidatorMiddleware(
       next();
     } catch (error) {
       next(
-        new Error("[middleware] Internal error while validating request", {
+        new Error("[middleware][request-validator] Internal error", {
           cause: error,
         }),
       );

--- a/src/middleware/version.ts
+++ b/src/middleware/version.ts
@@ -4,8 +4,9 @@ import { logMessage } from "@lib/logging/logger.js";
 export const versionMiddleware = (version: number) => {
   return (req: Request, _: Response, next: NextFunction) => {
     logMessage.debug(
-      `Version requested: ${req.params.version}, Current version: ${version}`,
+      `[middleware][version] Version requested: ${req.params.version}, Current version: ${version}`,
     );
+
     // If the version parameter is not defined, then we assume the latest version
     if (req.params.version === undefined) {
       return next();
@@ -17,6 +18,7 @@ export const versionMiddleware = (version: number) => {
     if (Number.isNaN(requestVersion)) {
       return next(new Error("Invalid API version requested."));
     }
+
     // If the requested version is greater than or equal to the current version, then we can proceed
     if (requestVersion >= version) {
       return next();

--- a/test/lib/formsClient/getPublicKey.test.ts
+++ b/test/lib/formsClient/getPublicKey.test.ts
@@ -48,7 +48,7 @@ describe("getPublicKey should", () => {
     vi.spyOn(DatabaseConnectorClient, "oneOrNone").mockRejectedValueOnce(
       customError,
     );
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    const logMessageSpy = vi.spyOn(logMessage, "info");
 
     await expect(() => getPublicKey("254354365464565461")).rejects.toThrowError(
       "custom error",

--- a/test/lib/integration/zitadelConnector.test.ts
+++ b/test/lib/integration/zitadelConnector.test.ts
@@ -37,7 +37,7 @@ describe("introspectAccessToken should", () => {
   it("throw an error if Zitadel post request fails", async () => {
     const connectionError = new ZitadelConnectionError();
     vi.spyOn(axios, "post").mockRejectedValueOnce(connectionError);
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    const logMessageSpy = vi.spyOn(logMessage, "info");
 
     await expect(() =>
       introspectAccessToken("accessToken"),
@@ -45,7 +45,9 @@ describe("introspectAccessToken should", () => {
 
     expect(logMessageSpy).toHaveBeenCalledWith(
       connectionError,
-      expect.stringContaining("[zitadel] Failed to introspect access token"),
+      expect.stringContaining(
+        "[zitadel-connector] Failed to introspect access token",
+      ),
     );
   });
 });

--- a/test/lib/logging/auditLogs.test.ts
+++ b/test/lib/logging/auditLogs.test.ts
@@ -51,7 +51,6 @@ describe("auditLog should", () => {
   it("console log audit log that failed to be published because of an internal error", async () => {
     const customError = new Error("custom error");
     sqsMock.on(SendMessageCommand).rejectsOnce(customError);
-    const warnLogMessageSpy = vi.spyOn(logMessage, "warn");
     const errorLogMessageSpy = vi.spyOn(logMessage, "error");
 
     await auditLog(
@@ -63,11 +62,7 @@ describe("auditLog should", () => {
 
     expect(errorLogMessageSpy).toHaveBeenCalledWith(
       customError,
-      expect.stringContaining("[logging] Failed to send audit log to AWS SQS"),
-    );
-
-    expect(warnLogMessageSpy).toHaveBeenCalledWith(
-      `[logging] Audit log that failed to be sent: ${JSON.stringify({ userId: "userId", event: "ConfirmResponse", timestamp: 1519129853500, subject: { type: "Response", id: "responseId" }, description: "description" })}`,
+      `[audit-log] Failed to send audit log to AWS SQS. Audit log: ${JSON.stringify({ userId: "userId", event: "ConfirmResponse", timestamp: 1519129853500, subject: { type: "Response", id: "responseId" }, description: "description" })}.`,
     );
   });
 });

--- a/test/lib/support/notifySupportAboutFormSubmissionProblem.test.ts
+++ b/test/lib/support/notifySupportAboutFormSubmissionProblem.test.ts
@@ -56,7 +56,7 @@ Here is my problem<br/>
   it("throw an error if the createTicket function has an internal failure", async () => {
     const customError = new Error("custom error");
     createFreshdeskTicketMock.mockRejectedValueOnce(customError);
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    const logMessageSpy = vi.spyOn(logMessage, "info");
 
     await expect(() =>
       notifySupportAboutFormSubmissionProblem(

--- a/test/lib/vault/confirmFormSubmission.test.ts
+++ b/test/lib/vault/confirmFormSubmission.test.ts
@@ -110,7 +110,7 @@ describe("confirmFormSubmission should", () => {
   it("throw an error if DynamoDB has an internal failure", async () => {
     const customError = new Error("custom error");
     dynamoDbMock.on(GetCommand).rejectsOnce(customError);
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    const logMessageSpy = vi.spyOn(logMessage, "info");
 
     await expect(() =>
       confirmFormSubmission(

--- a/test/lib/vault/getFormSubmission.test.ts
+++ b/test/lib/vault/getFormSubmission.test.ts
@@ -46,7 +46,7 @@ describe("getFormSubmission should", () => {
   it("throw an error if DynamoDB has an internal failure", async () => {
     const customError = new Error("custom error");
     dynamoDbMock.on(GetCommand).rejectsOnce(customError);
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    const logMessageSpy = vi.spyOn(logMessage, "info");
 
     await expect(() =>
       getFormSubmission("clzamy5qv0000115huc4bh90m", "01-08-a571"),

--- a/test/lib/vault/getNewFormSubmissions.test.ts
+++ b/test/lib/vault/getNewFormSubmissions.test.ts
@@ -147,7 +147,7 @@ describe("getNewFormSubmissions should", () => {
   it("throw an error if DynamoDB has an internal failure", async () => {
     const customError = new Error("custom error");
     dynamoDbMock.on(QueryCommand).rejectsOnce(customError);
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    const logMessageSpy = vi.spyOn(logMessage, "info");
 
     await expect(
       getNewFormSubmissions("clzamy5qv0000115huc4bh90m", 100),

--- a/test/lib/vault/reportProblemWithFormSubmission.test.ts
+++ b/test/lib/vault/reportProblemWithFormSubmission.test.ts
@@ -88,7 +88,7 @@ describe("reportProblemWithFormSubmission should", () => {
   it("throw an error if DynamoDB has an internal failure", async () => {
     const customError = new Error("custom error");
     dynamoDbMock.on(GetCommand).rejectsOnce(customError);
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    const logMessageSpy = vi.spyOn(logMessage, "info");
 
     await expect(() =>
       reportProblemWithFormSubmission(

--- a/test/middleware/authentication.test.ts
+++ b/test/middleware/authentication.test.ts
@@ -96,7 +96,7 @@ describe("authenticationMiddleware should", () => {
     await authenticationMiddleware(requestMock, responseMock, nextMock);
 
     expect(nextMock).toHaveBeenCalledWith(
-      new Error("[middleware] Internal error while authenticating user"),
+      new Error("[middleware][authentication] Internal error"),
     );
   });
 });

--- a/test/middleware/rateLimiter.test.ts
+++ b/test/middleware/rateLimiter.test.ts
@@ -76,7 +76,7 @@ describe("rateLimiterMiddleware should", () => {
       "Retry-After": 2,
     });
     expect(logMessageSpy).toHaveBeenCalledWith(
-      "[rate-limiter] Form clzsn6tao000611j50dexeob0 consumed all 10 tokens. Bucket will be refilled in 2 seconds",
+      "[middleware][rate-limiter] Form clzsn6tao000611j50dexeob0 consumed all 10 tokens. Bucket will be refilled in 2 seconds",
     );
     expect(responseMock.sendStatus).toHaveBeenCalledWith(429);
   });
@@ -89,7 +89,7 @@ describe("rateLimiterMiddleware should", () => {
     await rateLimiterMiddleware(requestMock, responseMock, nextMock);
 
     expect(nextMock).toHaveBeenCalledWith(
-      new Error("[middleware] Internal error with rate limiter"),
+      new Error("[middleware][rate-limiter] Internal error"),
     );
   });
 });

--- a/test/middleware/requestValidator.test.ts
+++ b/test/middleware/requestValidator.test.ts
@@ -90,7 +90,7 @@ describe("requestValidatorMiddleware should", () => {
     );
 
     expect(nextMock).toHaveBeenCalledWith(
-      new Error("[middleware] Internal error while validating request"),
+      new Error("[middleware][request-validator] Internal error"),
     );
   });
 });


### PR DESCRIPTION
# Summary | Résumé

- Makes API service compatible with AWS Scratch accounts (removed Localstack support)
- Reworks error logs to reduce noise on Slack (most low level logs have had their error level converted to info because they are used in a top level function that already generates either a warning or error log)