### PR TITLE
chore: bash example on how to interact with the API targets production instead of staging

### DIFF
--- a/examples/bash/.environment
+++ b/examples/bash/.environment
@@ -1,6 +1,6 @@
-api_url="https://api.forms-staging.cdssandbox.xyz"
-idp_url="https://auth.forms-staging.cdssandbox.xyz"
-project_id="275372254274006635"
+idp_url="https://auth.forms-formulaires.alpha.canada.ca"
+api_url="https://api.forms-formulaires.alpha.canada.ca"
+project_id="284778202772022819"
 
 json_key_file="$(find . -name "*_private_api_key.json" | head -n 1)"
 if [ -z "$json_key_file" ]; then

--- a/examples/bash/confirm_form_submission.sh
+++ b/examples/bash/confirm_form_submission.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
-source "$script_dir/.env.staging"
+source "$script_dir/.environment"
 
 # Confirm the form submission
 confirm_form_submission() {

--- a/examples/bash/decrypt_form_submission.sh
+++ b/examples/bash/decrypt_form_submission.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
-source "$script_dir/.env.staging"
+source "$script_dir/.environment"
 
 # Decrypt with the private key and return base64 output
 decrypt_with_private_key() {

--- a/examples/bash/get_access_token.sh
+++ b/examples/bash/get_access_token.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
-source "$script_dir/.env.staging"
+source "$script_dir/.environment"
 
 # Base64 encode a string
 base64_encode() {

--- a/examples/bash/get_form_submission.sh
+++ b/examples/bash/get_form_submission.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
-source "$script_dir/.env.staging"
+source "$script_dir/.environment"
 
 # Retrieve the encrypted form submission
 get_form_response() {

--- a/examples/bash/get_form_template.sh
+++ b/examples/bash/get_form_template.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
-source "$script_dir/.env.staging"
+source "$script_dir/.environment"
 
 # Retrieve the form template
 get_form_template() {

--- a/examples/bash/get_new_form_submissions.sh
+++ b/examples/bash/get_new_form_submissions.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
-source "$script_dir/.env.staging"
+source "$script_dir/.environment"
 
 # Retrieve the new form submission names
 get_new_form_submissions() {

--- a/examples/bash/report_problem_with_form_submission.sh
+++ b/examples/bash/report_problem_with_form_submission.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
-source "$script_dir/.env.staging"
+source "$script_dir/.environment"
 
 # Report problem with form submission
 report_problem_with_form_submission() {


### PR DESCRIPTION
# Summary | Résumé


- Makes the Bash example on how to interact with the API target production instead of staging like other examples