### PR TITLE
chore: update API integration examples to use latest version of frameworks/package dependencies

### DIFF
--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Download and install .NET version 8.0
+- Download and install .NET version 9.0
   - (with Microsoft installer) https://dotnet.microsoft.com/en-us/download
   - (with Brew) `brew install --cask dotnet-sdk`
 

--- a/examples/dotnet/dotnet.csproj
+++ b/examples/dotnet/dotnet.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.8.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
   </ItemGroup>
 
 </Project>

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -2,9 +2,9 @@
 
 ## Prerequisites
 
-- Download and install Node.js version 22
+- Download and install Node.js version 23
   - (with Node.js installer) https://nodejs.org/en/download/prebuilt-installer
-  - (with Brew) `brew install node@22`
+  - (with Brew) `brew install node@23`
 
 To make sure Node.js is properly installed, try to run the following command `node --version`.
 

--- a/examples/nodejs/package-lock.json
+++ b/examples/nodejs/package-lock.json
@@ -10,11 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4",
-        "jose": "^5.9.3"
+        "jose": "^6.0.10"
       },
       "devDependencies": {
-        "@types/node": "^22.7.4",
-        "typescript": "^5.6.2"
+        "@types/node": "^22.14.1",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@types/node": {
@@ -270,9 +270,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz",
+      "integrity": "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -10,10 +10,10 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.8.4",
-    "jose": "^5.9.3"
+    "jose": "^6.0.10"
   },
   "devDependencies": {
-    "@types/node": "^22.7.4",
-    "typescript": "^5.6.2"
+    "@types/node": "^22.14.1",
+    "typescript": "^5.8.3"
   }
 }

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -84,7 +84,7 @@ Selection (1):
                 )
 
                 print(
-                    f"\nIntegrity verification result: {"OK" if integrity_verification_result else "INVALID"}"
+                    f"\nIntegrity verification result: {'OK' if integrity_verification_result else 'INVALID'}"
                 )
 
                 print("\nConfirming submission...")

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "aws-sdk-client-mock": "^4.0.2",
     "pino-pretty": "^11.2.2",
     "supertest": "^7.0.0",
-    "tsc-alias": "1.8.13",
+    "tsc-alias": "^1.8.15",
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
     "vite-tsconfig-paths": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^7.0.0
         version: 7.1.0
       tsc-alias:
-        specifier: 1.8.13
-        version: 1.8.13
+        specifier: ^1.8.15
+        version: 1.8.15
       tsx:
         specifier: ^4.19.1
         version: 4.19.3
@@ -1837,8 +1837,8 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tsc-alias@1.8.13:
-    resolution: {integrity: sha512-hpuglrm2DoHZE62L8ntYqRNiSQ7J8kvIxEsajzY/QfGOm7EcdhgG5asqoWYi2E2KX0SqUuhOTnV8Ry8D/TnsEA==}
+  tsc-alias@1.8.15:
+    resolution: {integrity: sha512-yKLVx8ddUurRwhVcS6JFF2ZjksOX2ZWDRIdgt+PQhJBDegIdAdilptiHsuAbx9UFxa16GFrxeKQ2kTcGvR6fkQ==}
     engines: {node: '>=16.20.2'}
     hasBin: true
 
@@ -4066,10 +4066,11 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tsc-alias@1.8.13:
+  tsc-alias@1.8.15:
     dependencies:
       chokidar: 3.6.0
       commander: 9.5.0
+      get-tsconfig: 4.10.0
       globby: 11.1.0
       mylas: 2.1.13
       normalize-path: 3.0.0


### PR DESCRIPTION
# Summary | Résumé

- Updates all API integration examples to use latest version for frameworks and package dependencies
- Uses latest version of `tsc-alias` for the API build now that it got fixed (https://github.com/justkey007/tsc-alias/commit/3e55ed9a8fc14a9a59ec490f2a0ecedc8dd509ea)