### PR TITLE
chore:  switch to CDS Release Bot

### DIFF
--- a/.github/workflows/release-generator.yml
+++ b/.github/workflows/release-generator.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: sre_app_token
         with:
-          app-id: ${{ secrets.SRE_APP_ID }}
-          private-key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.CDS_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.CDS_RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:


### PR DESCRIPTION
# Summary
Update the release please workflow to use a dedicated GitHub app for releases. This will allow us to scale back the use of the SRE read/write GitHub app.

# Related
- https://github.com/cds-snc/platform-core-services/issues/707