### PR TITLE
chore: revert complex status endpoint logic

### DIFF
--- a/src/operations/checkServiceHealth.ts
+++ b/src/operations/checkServiceHealth.ts
@@ -1,82 +1,10 @@
 import type { Request, Response } from "express";
 import type { ApiOperation } from "@operations/types/operation.js";
-import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
-import { ScanCommand } from "@aws-sdk/lib-dynamodb";
-import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
-import { logMessage } from "@lib/logging/logger.js";
-import { ZITADEL_DOMAIN } from "@config";
-import { DatabaseConnectorClient } from "@lib/integration/databaseConnector.js";
-import axios from "axios";
 
-type ServiceHealthCheckResult = {
-  service: "dynamodb" | "redis" | "postgresql" | "zitadel";
-  isHealthy: boolean;
-};
-
-async function main(_: Request, response: Response): Promise<void> {
-  const serviceHealthCheckResults = await Promise.all([
-    checkDynamoDbServiceHealth(),
-    checkRedisServiceHealth(),
-    checkPostgreSqlServiceHealth(),
-    checkZitadelServiceHealth(),
-  ]);
-
-  logMessage.info(
-    `[service-health] ${serviceHealthCheckResults.map((r) => `${r.service} => ${r.isHealthy ? "healthy" : "unhealthy"}`).join(" | ")}`,
-  );
-
-  if (serviceHealthCheckResults.some((r) => r.isHealthy === false)) {
-    response.sendStatus(503);
-    return;
-  }
-
+function main(_: Request, response: Response): void {
   response.json({
-    status: "healthy",
+    status: "running",
   });
-}
-
-function checkDynamoDbServiceHealth(): Promise<ServiceHealthCheckResult> {
-  return AwsServicesConnector.getInstance()
-    .dynamodbClient.send(
-      new ScanCommand({
-        TableName: "Vault",
-        Limit: 1,
-      }),
-    )
-    .then(
-      () => true,
-      () => false,
-    )
-    .then((isHealthy) => ({ service: "dynamodb", isHealthy }));
-}
-
-function checkRedisServiceHealth(): Promise<ServiceHealthCheckResult> {
-  return RedisConnector.getInstance()
-    .then((redisConnector) => redisConnector.client.ping())
-    .then(
-      () => true,
-      () => false,
-    )
-    .then((isHealthy) => ({ service: "redis", isHealthy }));
-}
-
-function checkPostgreSqlServiceHealth(): Promise<ServiceHealthCheckResult> {
-  return DatabaseConnectorClient.query("SELECT 1")
-    .then(
-      () => true,
-      () => false,
-    )
-    .then((isHealthy) => ({ service: "postgresql", isHealthy }));
-}
-
-function checkZitadelServiceHealth(): Promise<ServiceHealthCheckResult> {
-  return axios
-    .get(`${ZITADEL_DOMAIN}/debug/ready`, { timeout: 5000 })
-    .then(
-      () => true, // Zitadel answered with HTTP status 200
-      () => false, // Zitadel answered with HTTP status 412
-    )
-    .then((isHealthy) => ({ service: "zitadel", isHealthy }));
 }
 
 export const checkServiceHealthOperation: ApiOperation = {

--- a/test/operations/checkServiceHealth.test.ts
+++ b/test/operations/checkServiceHealth.test.ts
@@ -1,42 +1,16 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { getMockReq, getMockRes } from "vitest-mock-express";
 import { checkServiceHealthOperation } from "@operations/checkServiceHealth.js";
-import { DatabaseConnectorClient } from "@lib/integration/databaseConnector.js";
-import { mockClient } from "aws-sdk-client-mock";
-import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
-import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
-import { logMessage } from "@lib/logging/logger.js";
-import axios from "axios";
-
-const dynamoDbMock = mockClient(DynamoDBDocumentClient);
-
-vi.mock("@lib/integration/redis/redisConnector");
-const redisConnectorMock = vi.mocked(RedisConnector);
-
-// biome-ignore lint/suspicious/noExplicitAny: we need to assign the Redis client and allow mock resolved values
-const redisClient: any = {
-  ping: vi.fn(),
-};
-
-redisConnectorMock.getInstance.mockResolvedValue({ client: redisClient });
-
-const logMessageSpy = vi.spyOn(logMessage, "info");
 
 describe("checkServiceHealthOperation handler should", () => {
-  const requestMock = getMockReq();
   const { res: responseMock, next: nextMock, clearMockRes } = getMockRes();
 
   beforeEach(() => {
-    vi.clearAllMocks();
     clearMockRes();
-    dynamoDbMock.reset();
   });
 
-  it("respond with success if all internal services are healthy", async () => {
-    dynamoDbMock.on(ScanCommand).resolvesOnce({ Items: [] });
-    redisClient.ping.mockResolvedValueOnce("PONG");
-    vi.spyOn(DatabaseConnectorClient, "query").mockResolvedValueOnce(1);
-    vi.spyOn(axios, "get").mockResolvedValueOnce({});
+  it("respond with running status if service is healthy", async () => {
+    const requestMock = getMockReq();
 
     await checkServiceHealthOperation.handler(
       requestMock,
@@ -44,83 +18,6 @@ describe("checkServiceHealthOperation handler should", () => {
       nextMock,
     );
 
-    expect(logMessageSpy).toHaveBeenCalledWith(
-      "[service-health] dynamodb => healthy | redis => healthy | postgresql => healthy | zitadel => healthy",
-    );
-    expect(responseMock.json).toHaveBeenCalledWith({ status: "healthy" });
-  });
-
-  it("respond with error if DynamoDB service is unhealthy", async () => {
-    dynamoDbMock.on(ScanCommand).rejectsOnce(new Error("custom error"));
-    redisClient.ping.mockResolvedValueOnce("PONG");
-    vi.spyOn(DatabaseConnectorClient, "query").mockResolvedValueOnce(1);
-    vi.spyOn(axios, "get").mockResolvedValueOnce({});
-
-    await checkServiceHealthOperation.handler(
-      requestMock,
-      responseMock,
-      nextMock,
-    );
-
-    expect(logMessageSpy).toHaveBeenCalledWith(
-      "[service-health] dynamodb => unhealthy | redis => healthy | postgresql => healthy | zitadel => healthy",
-    );
-    expect(responseMock.sendStatus).toHaveBeenCalledWith(503);
-  });
-
-  it("respond with error if Redis service is unhealthy", async () => {
-    dynamoDbMock.on(ScanCommand).resolvesOnce({ Items: [] });
-    redisClient.ping.mockRejectedValueOnce(new Error("custom error"));
-    vi.spyOn(DatabaseConnectorClient, "query").mockResolvedValueOnce(1);
-    vi.spyOn(axios, "get").mockResolvedValueOnce({});
-
-    await checkServiceHealthOperation.handler(
-      requestMock,
-      responseMock,
-      nextMock,
-    );
-
-    expect(logMessageSpy).toHaveBeenCalledWith(
-      "[service-health] dynamodb => healthy | redis => unhealthy | postgresql => healthy | zitadel => healthy",
-    );
-    expect(responseMock.sendStatus).toHaveBeenCalledWith(503);
-  });
-
-  it("respond with error if PostgreSQL service is unhealthy", async () => {
-    dynamoDbMock.on(ScanCommand).resolvesOnce({ Items: [] });
-    redisClient.ping.mockResolvedValueOnce("PONG");
-    vi.spyOn(DatabaseConnectorClient, "query").mockRejectedValueOnce(
-      new Error("custom error"),
-    );
-    vi.spyOn(axios, "get").mockResolvedValueOnce({});
-
-    await checkServiceHealthOperation.handler(
-      requestMock,
-      responseMock,
-      nextMock,
-    );
-
-    expect(logMessageSpy).toHaveBeenCalledWith(
-      "[service-health] dynamodb => healthy | redis => healthy | postgresql => unhealthy | zitadel => healthy",
-    );
-    expect(responseMock.sendStatus).toHaveBeenCalledWith(503);
-  });
-
-  it("respond with error if Zitadel service is unhealthy", async () => {
-    dynamoDbMock.on(ScanCommand).resolvesOnce({ Items: [] });
-    redisClient.ping.mockResolvedValueOnce("PONG");
-    vi.spyOn(DatabaseConnectorClient, "query").mockResolvedValueOnce(1);
-    vi.spyOn(axios, "get").mockRejectedValueOnce(new Error("custom error"));
-
-    await checkServiceHealthOperation.handler(
-      requestMock,
-      responseMock,
-      nextMock,
-    );
-
-    expect(logMessageSpy).toHaveBeenCalledWith(
-      "[service-health] dynamodb => healthy | redis => healthy | postgresql => healthy | zitadel => unhealthy",
-    );
-    expect(responseMock.sendStatus).toHaveBeenCalledWith(503);
+    expect(responseMock.json).toHaveBeenCalledWith({ status: "running" });
   });
 });

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -15,7 +15,6 @@ process.env = {
 
 vi.mock("./src/lib/integration/databaseConnector", () => ({
   DatabaseConnectorClient: {
-    query: vi.fn(),
     oneOrNone: vi.fn(),
   },
 }));
@@ -27,7 +26,6 @@ vi.mock("./src/lib/logging/auditLogs", () => ({
 vi.mock("axios", () => {
   return {
     default: {
-      get: vi.fn().mockResolvedValue({}),
       post: vi.fn().mockResolvedValue({}),
     },
   };
@@ -49,7 +47,6 @@ vi.mock("redis", () => {
     connect: vi.fn().mockResolvedValue({}),
     quit: vi.fn(),
     on: vi.fn().mockReturnThis(),
-    ping: vi.fn(),
   };
   return {
     createClient: vi.fn(() => client),


### PR DESCRIPTION
# Summary | Résumé

- Reverts `/status` endpoint changes to make it simple and just return HTTP 200 with JSON { "status": "running" }