### PR TITLE
chore: add submission attachments support to API examples

### DIFF
--- a/examples/bash/README.md
+++ b/examples/bash/README.md
@@ -16,16 +16,13 @@ Put the private key file you have generated through the GCForms web application 
 The scripts are meant to be run in order to give you an idea of how the request flow works.
 
 1. `get_access_token.sh`: generates a JSON web token and request an access key.
-2. `get_new_form_submissions.sh`: retrieves a list of submissions for your form.
-3. `get_form_submission.sh`: retrieves an encrypted form response. Use one of the form submission name properties from the new form submissions. 
-4. `decrypt_form_submission.sh`: decrypt a retrieved form submission. The easiest to test this is as follows:
-```sh
-# Capture the encrypted response in a file
-./get_form_submission.sh > form_response.json
-./decrypt_form_submission.sh
-```
-5. `validate_form_submission.sh`: checks that the form submission has not been altered during transit. The 'answers' and 'checksum' values are part of the decrypted form response.
-6. `confirm_form_submission.sh`: confirms receipt of a form submission. The confirmation code is included with the decrypted form response.
-7. `get_form_template.sh`: optionally, retrieve the form template used by GC Forms to build and display the form to users.
+2. `get_new_form_submissions.sh <access_token>`: retrieves a list of submissions for your form.
+3. `get_form_submission.sh <access_token> <submission_name>`: retrieves an encrypted form response. Use one of the form submission name properties from the new form submissions. 
+4. `decrypt_form_submission.sh <form_submission_json>`: decrypt a retrieved form submission. The easiest to test this is as follows:
+5. `validate_form_submission.sh <answers> <checksum>`: checks that the form submission has not been altered during transit. The 'answers' and 'checksum' values are part of the decrypted form response.
+6. `confirm_form_submission.sh <access_token> <submission_name> <confirmation_code>`: confirms receipt of a form submission. The confirmation code is included with the decrypted form response.
+7. `get_form_template.sh <access_token>`: optionally, retrieve the form template used by GC Forms to build and display the form to users.
+
+This script, `retrieve_save_confirm_form_submissions.sh`, illustrates how to use the smaller scripts above to fetch the oldest unconfirmed submission, save it to a local folder, and confirm it.
 
 To report a problem with a form submission you have downloaded you can use `report_problem_with_form_submission.sh`.

--- a/examples/bash/confirm_form_submission.sh
+++ b/examples/bash/confirm_form_submission.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <access_token> <submission_name> <confirmation_code>"
+    exit 1
+fi
+
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
 source "$script_dir/.environment"
@@ -16,8 +21,4 @@ confirm_form_submission() {
     -H "Content-Type: application/json"
 }
 
-read -p "Enter the form submission name: " submission_name
-read -p "Enter the form submission confirmation code: " confirmation_code
-read -p "Enter your access token: " access_token
-
-confirm_form_submission "$access_token" "$submission_name" "$confirmation_code"
+confirm_form_submission "$1" "$2" "$3"

--- a/examples/bash/decrypt_form_submission.sh
+++ b/examples/bash/decrypt_form_submission.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <form_submission_json>"
+    exit 1
+fi
+
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
 source "$script_dir/.environment"
@@ -12,13 +17,11 @@ decrypt_with_private_key() {
   echo "$encrypted_data" | base64 -d | openssl pkeyutl -decrypt -inkey <(echo "$private_key") -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256 | base64
 }
 
-read -p "Enter the path to the encrypted form submission JSON: " form_submission_json
-
 # Pull the values out of the response JSON
-encrypted_key="$(jq -r '.encryptedKey' "$form_submission_json")"
-encrypted_nonce="$(jq -r '.encryptedNonce' "$form_submission_json")"
-encrypted_auth_tag="$(jq -r '.encryptedAuthTag' "$form_submission_json")"
-encrypted_responses="$(jq -r '.encryptedResponses' "$form_submission_json")"
+encrypted_key="$(echo "$1" | jq -r '.encryptedKey')"
+encrypted_nonce="$(echo "$1" | jq -r '.encryptedNonce')"
+encrypted_auth_tag="$(echo "$1" | jq -r '.encryptedAuthTag')"
+encrypted_responses="$(echo "$1" | jq -r '.encryptedResponses')"
 
 # Decrypt the key, nonce, and auth tag using the private key
 private_key="$(jq -r '.key' "$json_key_file")"

--- a/examples/bash/get_form_submission.sh
+++ b/examples/bash/get_form_submission.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <access_token> <submission_name>"
+    exit 1
+fi
+
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
 source "$script_dir/.environment"
@@ -15,7 +20,4 @@ get_form_response() {
     -H "Content-Type: application/json"
 }
 
-read -p "Enter the form submission name: " submission_name
-read -p "Enter your access token: " access_token
-
-get_form_response "$access_token" "$submission_name"
+get_form_response "$1" "$2"

--- a/examples/bash/get_form_template.sh
+++ b/examples/bash/get_form_template.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <access_token>"
+    exit 1
+fi
+
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
 source "$script_dir/.environment"
@@ -14,6 +19,4 @@ get_form_template() {
     -H "Content-Type: application/json"
 }
 
-read -p "Enter your access token: " access_token
-
-get_form_template "$access_token"
+get_form_template "$1"

--- a/examples/bash/get_new_form_submissions.sh
+++ b/examples/bash/get_new_form_submissions.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <access_token>"
+    exit 1
+fi
+
 # Load environment vars
 script_dir=$(dirname "$(realpath "$0")")
 source "$script_dir/.environment"
@@ -14,6 +19,4 @@ get_new_form_submissions() {
     -H "Content-Type: application/json"
 }
 
-read -p "Enter your access token: " access_token
-
-get_new_form_submissions "$access_token"
+get_new_form_submissions "$1"

--- a/examples/bash/retrieve_save_confirm_form_submissions.sh
+++ b/examples/bash/retrieve_save_confirm_form_submissions.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+truncate_string() {
+    local str="$1"
+    local maxlen=2000
+
+    if [ ${#str} -gt "2000" ]; then
+        echo "${str:0:2000}..."
+    else
+        echo "$str"
+    fi
+}
+
+echo -e "\nGenerating access token..."
+
+access_token=$(./get_access_token.sh)
+
+echo -e "\nRetrieving form template...\n";
+
+form_template=$(./get_form_template.sh "$access_token")
+
+echo $(truncate_string "$form_template")
+
+echo -e "\nRetrieving new form submissions..."
+
+new_form_submissions=$(./get_new_form_submissions.sh "$access_token")
+
+if [ "$(echo "$new_form_submissions" | jq 'length')" -eq 0 ]; then
+    echo -e "\nCould not find any new form submission!"
+else
+    echo -e "\nNew form submissions:"
+    echo "$new_form_submissions" | jq -r '[.[].name] | join(", ")'
+
+    echo -e "\nRetrieving, decrypting and confirming form submissions..."
+
+    echo "$new_form_submissions" | jq -r '.[].name' | while IFS= read -r new_form_submission_name; do
+        echo -e "\nProcessing $new_form_submission_name...\n"
+
+        echo "Retrieving encrypted submission..."
+
+        encrypted_form_submission=$(./get_form_submission.sh "$access_token" "$new_form_submission_name")
+
+        echo -e "\nEncrypted submission:"
+        echo $(truncate_string $(echo "$encrypted_form_submission" | jq -r '.encryptedResponses'))
+
+        echo -e "\nDecrypting submission..."
+
+        decrypted_form_submission=$(./decrypt_form_submission.sh "$encrypted_form_submission")
+
+        echo -e "\nDecrypted submission:"
+        echo $(truncate_string "$decrypted_form_submission")
+
+        echo -e "\nVerifying submission integrity...\n"
+
+        answers=$(echo $decrypted_form_submission | jq -r '.answers')
+        checksum=$(echo $decrypted_form_submission | jq -r '.checksum')
+        confirmation_code=$(echo $decrypted_form_submission | jq -r '.confirmationCode')
+
+        echo $(./validate_form_submission.sh "$answers" "$checksum")
+
+        mkdir -p "$new_form_submission_name"
+
+        echo -e "\nSaving submission answers..."
+
+        echo "$answers" > "$new_form_submission_name/answers.json"
+
+        list_of_attachments=$(echo "$decrypted_form_submission" | jq -c '.attachments[]?')
+
+        if [ ! -z "$list_of_attachments" ]; then
+          echo -e "\nSaving submission attachments...\n"
+
+          echo "$list_of_attachments" | while IFS= read -r attachment; do
+            file_name=$(echo "$attachment" | jq -r '.name')
+            download_link=$(echo "$attachment" | jq -r '.downloadLink')
+            is_potentially_malicious=$(echo "$attachment" | jq -r '.isPotentiallyMalicious')
+
+            curl -sSL "$download_link" -o "$new_form_submission_name/$file_name"
+
+            msg="Submission attachment '$file_name' has been saved"
+            if [ "$is_potentially_malicious" = true ]; then
+                msg="$msg (flagged as potentially malicious)"
+            fi
+            echo "$msg"
+          done
+        fi
+
+        echo -e "\nSubmission saved in folder named '${new_form_submission_name}'"
+
+        echo -e "\nConfirming submission..."
+
+        ./confirm_form_submission.sh "$access_token" "$new_form_submission_name" "$confirmation_code" > /dev/null
+
+        echo -e "\nSubmission confirmed"
+
+        read -n 1 -s -r -p $'\n=> Press any key to continue processing form submissions or Ctrl-C to exit' </dev/tty
+        echo
+    done
+fi

--- a/examples/bash/validate_form_submission.sh
+++ b/examples/bash/validate_form_submission.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <answers> <checksum>"
+    exit 1
+fi
+
 # Calculate the form response's 'answers' checksum and compare it to the checksum
 # calculated at submission. The form response JSON has the following structure:
 #
@@ -30,7 +35,4 @@ verify_integrity() {
   fi
 }
 
-read -p "Enter the form response 'answers' property: " answers
-read -p "Enter the form response 'checksum' property: " checksum
-
-verify_integrity "$answers" "$checksum"
+verify_integrity "$1" "$2"

--- a/examples/dotnet/DataStructures.cs
+++ b/examples/dotnet/DataStructures.cs
@@ -47,6 +47,15 @@ namespace dotnet
     Problem,
   }
 
+  public struct Attachment
+  {
+    public required string name { get; set; }
+
+    public required string downloadLink { get; set; }
+
+    public required bool isPotentiallyMalicious { get; set; }
+  }
+
   public struct FormSubmission
   {
     public required ulong createdAt { get; set; }
@@ -59,6 +68,8 @@ namespace dotnet
     public required string answers { get; set; }
 
     public required string checksum { get; set; }
+
+    public List<Attachment>? attachments { get; set; }
   }
 
   public struct FormSubmissionProblem

--- a/examples/dotnet/GCFormsApiClient.cs
+++ b/examples/dotnet/GCFormsApiClient.cs
@@ -35,7 +35,7 @@ namespace dotnet
           .Result
           .EnsureSuccessStatusCode()
           .Content
-          .ReadFromJsonAsync<object>();
+          .ReadFromJsonAsync<object>()!;
       }
       catch (Exception exception)
       {
@@ -53,7 +53,7 @@ namespace dotnet
           .Result
           .EnsureSuccessStatusCode()
           .Content
-          .ReadFromJsonAsync<List<NewFormSubmission>>();
+          .ReadFromJsonAsync<List<NewFormSubmission>>()!;
       }
       catch (Exception exception)
       {
@@ -79,15 +79,14 @@ namespace dotnet
       }
     }
 
-    public async Task ConfirmFormSubmission(string submissionName, string confirmationCode)
+    public Task ConfirmFormSubmission(string submissionName, string confirmationCode)
     {
       try
       {
-        HttpResponseMessage response = await this
+        return this
           .httpClient
-          .PutAsync($"/forms/{this.formId}/submission/{submissionName}/confirm/{confirmationCode}", null);
-
-        response.EnsureSuccessStatusCode();
+          .PutAsync($"/forms/{this.formId}/submission/{submissionName}/confirm/{confirmationCode}", null)
+          .ContinueWith(t => t.Result.EnsureSuccessStatusCode());
       }
       catch (Exception exception)
       {
@@ -95,18 +94,17 @@ namespace dotnet
       }
     }
 
-    public async Task ReportProblemWithFormSubmission(string submissionName, FormSubmissionProblem problem)
+    public Task ReportProblemWithFormSubmission(string submissionName, FormSubmissionProblem problem)
     {
       try
       {
-        HttpResponseMessage response = await this
+        return this
           .httpClient
           .PostAsync(
             $"/forms/{this.formId}/submission/{submissionName}/problem",
             new StringContent(JsonSerializer.Serialize(problem), Encoding.UTF8, "application/json")
-          );
-
-        response.EnsureSuccessStatusCode();
+          )
+          .ContinueWith(t => t.Result.EnsureSuccessStatusCode());
       }
       catch (Exception exception)
       {

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -9,6 +9,8 @@ namespace dotnet
     static readonly string PROJECT_IDENTIFIER = "284778202772022819";
     static readonly string GCFORMS_API_URL = "https://api.forms-formulaires.alpha.canada.ca";
 
+    static readonly HttpClient sharedHttpClient = new();
+
     static async Task Main(string[] args)
     {
       try
@@ -20,126 +22,18 @@ I want to:
 (1) Generate and display an access token
 (2) Retrieve, decrypt and confirm form submissions
 (3) Report a problem with a form submission
-Selection (1):
-");
+Selection (1):");
 
         switch (Console.ReadLine())
         {
-          case "1":
-          default:
-            {
-              Console.WriteLine("\nGenerating access token...");
-
-              string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
-
-              Console.WriteLine("\nGenerated access token:");
-              Console.WriteLine(accessToken);
-            }
-            break;
           case "2":
-            {
-              Console.WriteLine("\nGenerating access token...");
-
-              string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
-
-              GCFormsApiClient apiClient = new(privateApiKey.formId, GCFORMS_API_URL, accessToken);
-
-              Console.WriteLine("\nRetrieving form template...\n");
-
-              object formTemplate = await apiClient.GetFormTemplate();
-
-              Console.WriteLine(formTemplate);
-
-              Console.WriteLine("\nRetrieving new form submissions...");
-
-              List<NewFormSubmission> newFormSubmissions = await apiClient.GetNewFormSubmissions();
-
-              if (newFormSubmissions.Count > 0)
-              {
-                Console.WriteLine($"\nNew form submissions:");
-                Console.WriteLine(string.Join(", ", newFormSubmissions.Select(x => x.name)));
-
-                Console.WriteLine("\nRetrieving, decrypting and confirming form submissions...");
-
-                foreach (NewFormSubmission newFormSubmission in newFormSubmissions)
-                {
-                  Console.WriteLine($"\nProcessing {newFormSubmission.name}...\n");
-
-                  Console.WriteLine("Retrieving encrypted submission...");
-
-                  EncryptedFormSubmission encryptedSubmission = await apiClient.GetFormSubmission(newFormSubmission.name);
-
-                  Console.WriteLine("\nEncrypted submission:");
-                  Console.WriteLine(encryptedSubmission.encryptedResponses);
-
-                  Console.WriteLine("\nDecrypting submission...");
-
-                  string decryptedFormSubmission = FormSubmissionDecrypter.Decrypt(encryptedSubmission, privateApiKey);
-
-                  Console.WriteLine("\nDecrypted submission:");
-                  Console.WriteLine(decryptedFormSubmission);
-
-                  FormSubmission formSubmission = JsonSerializer.Deserialize<FormSubmission>(decryptedFormSubmission);
-
-                  Console.WriteLine("\nVerifying submission integrity...");
-
-                  bool integrityVerificationResult = FormSubmissionIntegrityVerifier.VerifyIntegrity(formSubmission.answers, formSubmission.checksum);
-
-                  Console.WriteLine($"\nIntegrity verification result: {(integrityVerificationResult ? "OK" : "INVALID")}");
-
-                  Console.WriteLine("\nConfirming submission...");
-
-                  await apiClient.ConfirmFormSubmission(newFormSubmission.name, formSubmission.confirmationCode);
-
-                  Console.WriteLine("\nSubmission confirmed");
-
-                  Console.WriteLine("\n=> Press any key to continue processing form submissions or Ctrl-C to exit");
-                  Console.ReadKey();
-                }
-              }
-              else
-              {
-                Console.WriteLine($"\nCould not find any new form submission!");
-              }
-            }
+            await RunRetrieveDecryptAndConfirmFormSubmissions(privateApiKey);
             break;
           case "3":
-            {
-              Console.WriteLine("\nSubmission name:");
-
-              string submissionName = Console.ReadLine();
-
-              Console.WriteLine("\nContact email address:");
-
-              string contactEmail = Console.ReadLine();
-
-              Console.WriteLine("\nProblem description (10 characters minimum):");
-
-              string description = Console.ReadLine();
-
-              Console.WriteLine("\nPreferred communication language (either 'en' or 'fr'):");
-
-              string preferredLanguage = Console.ReadLine();
-
-              Console.WriteLine("\nGenerating access token...");
-
-              string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
-
-              GCFormsApiClient apiClient = new(privateApiKey.formId, GCFORMS_API_URL, accessToken);
-
-              Console.WriteLine("\nReporting form submission...");
-
-              FormSubmissionProblem problem = new()
-              {
-                contactEmail = contactEmail,
-                description = description,
-                preferredLanguage = preferredLanguage
-              };
-
-              await apiClient.ReportProblemWithFormSubmission(submissionName, problem);
-
-              Console.WriteLine($"\nSubmission has been reported");
-            }
+            await RunReportProblemWithFormSubmission(privateApiKey);
+            break;
+          default:
+            await RunGenerateAccessToken(privateApiKey);
             break;
         }
       }
@@ -147,6 +41,165 @@ Selection (1):
       {
         Console.WriteLine(exception.ToString());
       }
+    }
+
+    static async Task RunGenerateAccessToken(PrivateApiKey privateApiKey)
+    {
+      Console.WriteLine("\nGenerating access token...");
+
+      string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
+
+      Console.WriteLine("\nGenerated access token:");
+      Console.WriteLine(accessToken);
+    }
+
+    static async Task RunRetrieveDecryptAndConfirmFormSubmissions(PrivateApiKey privateApiKey)
+    {
+      Console.WriteLine("\nGenerating access token...");
+
+      string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
+
+      GCFormsApiClient apiClient = new(privateApiKey.formId, GCFORMS_API_URL, accessToken);
+
+      Console.WriteLine("\nRetrieving form template...\n");
+
+      object formTemplate = await apiClient.GetFormTemplate();
+
+      Console.WriteLine(TruncateString(JsonSerializer.Serialize(formTemplate)));
+
+      Console.WriteLine("\nRetrieving new form submissions...");
+
+      List<NewFormSubmission> newFormSubmissions = await apiClient.GetNewFormSubmissions();
+
+      if (newFormSubmissions.Count > 0)
+      {
+        Console.WriteLine($"\nNew form submissions:");
+        Console.WriteLine(string.Join(", ", newFormSubmissions.Select(x => x.name)));
+
+        Console.WriteLine("\nRetrieving, decrypting and confirming form submissions...");
+
+        foreach (NewFormSubmission newFormSubmission in newFormSubmissions)
+        {
+          Console.WriteLine($"\nProcessing {newFormSubmission.name}...\n");
+
+          Console.WriteLine("Retrieving encrypted submission...");
+
+          EncryptedFormSubmission encryptedSubmission = await apiClient.GetFormSubmission(newFormSubmission.name);
+
+          Console.WriteLine("\nEncrypted submission:");
+          Console.WriteLine(TruncateString(encryptedSubmission.encryptedResponses));
+
+          Console.WriteLine("\nDecrypting submission...");
+
+          string decryptedFormSubmission = FormSubmissionDecrypter.Decrypt(encryptedSubmission, privateApiKey);
+
+          Console.WriteLine("\nDecrypted submission:");
+          Console.WriteLine(TruncateString(decryptedFormSubmission));
+
+          FormSubmission formSubmission = JsonSerializer.Deserialize<FormSubmission>(decryptedFormSubmission);
+
+          Console.WriteLine("\nVerifying submission integrity...");
+
+          bool integrityVerificationResult = FormSubmissionIntegrityVerifier.VerifyIntegrity(formSubmission.answers, formSubmission.checksum);
+
+          Console.WriteLine($"\nIntegrity verification result: {(integrityVerificationResult ? "OK" : "INVALID")}");
+
+          await SaveSubmissionLocally(newFormSubmission.name, formSubmission);
+
+          Console.WriteLine("\nConfirming submission...");
+
+          await apiClient.ConfirmFormSubmission(newFormSubmission.name, formSubmission.confirmationCode);
+
+          Console.WriteLine("\nSubmission confirmed");
+
+          Console.WriteLine("\n=> Press any key to continue processing form submissions or Ctrl-C to exit");
+          Console.ReadKey();
+        }
+      }
+      else
+      {
+        Console.WriteLine($"\nCould not find any new form submission!");
+      }
+    }
+
+    static async Task SaveSubmissionLocally(string submissionName, FormSubmission submission)
+    {
+      Console.WriteLine("\nSaving submission answers...");
+
+      string submissionFolderPath = Path.Combine(".", submissionName);
+
+      Directory.CreateDirectory(submissionFolderPath);
+
+      await File.WriteAllTextAsync(Path.Combine(submissionFolderPath, "answers.json"), submission.answers);
+
+      if (submission.attachments != null)
+      {
+        Console.WriteLine("\nSaving submission attachments...\n");
+        await Task.WhenAll(submission.attachments.Select(t => DownloadAndSaveAttachment(t, submissionFolderPath)));
+      }
+
+      Console.WriteLine($"\nSubmission saved in folder named '{Path.GetFileName(submissionFolderPath)}'");
+    }
+
+    static Task DownloadAndSaveAttachment(Attachment attachment, string submissionFolderPath)
+    {
+      try
+      {
+        return sharedHttpClient
+          .GetAsync(attachment.downloadLink, HttpCompletionOption.ResponseHeadersRead)
+          .Result
+          .EnsureSuccessStatusCode()
+          .Content
+          .CopyToAsync(new FileStream(Path.Combine(submissionFolderPath, attachment.name), FileMode.Create, FileAccess.Write, FileShare.None))
+          .ContinueWith(_ => Console.WriteLine($"Submission attachment '{attachment.name}' has been saved {(attachment.isPotentiallyMalicious ? "(flagged as potentially malicious)" : "")}"));
+      }
+      catch (Exception exception)
+      {
+        throw new Exception($"Failed to download and save submission attachment {attachment.name}", exception);
+      }
+    }
+
+    static async Task RunReportProblemWithFormSubmission(PrivateApiKey privateApiKey)
+    {
+      Console.WriteLine("\nSubmission name:");
+
+      string? submissionName = Console.ReadLine();
+
+      Console.WriteLine("\nContact email address:");
+
+      string? contactEmail = Console.ReadLine();
+
+      Console.WriteLine("\nProblem description (10 characters minimum):");
+
+      string? description = Console.ReadLine();
+
+      Console.WriteLine("\nPreferred communication language (either 'en' or 'fr'):");
+
+      string? preferredLanguage = Console.ReadLine();
+
+      Console.WriteLine("\nGenerating access token...");
+
+      if (submissionName == null || contactEmail == null || description == null || preferredLanguage == null)
+      {
+        throw new Exception("Missing one or multiple user inputs");
+      }
+
+      string accessToken = await AccessTokenGenerator.Generate(IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, privateApiKey);
+
+      GCFormsApiClient apiClient = new(privateApiKey.formId, GCFORMS_API_URL, accessToken);
+
+      Console.WriteLine("\nReporting form submission...");
+
+      FormSubmissionProblem problem = new()
+      {
+        contactEmail = contactEmail,
+        description = description,
+        preferredLanguage = preferredLanguage
+      };
+
+      await apiClient.ReportProblemWithFormSubmission(submissionName, problem);
+
+      Console.WriteLine($"\nSubmission has been reported");
     }
 
     static PrivateApiKey LoadPrivateApiKey()
@@ -169,6 +222,14 @@ Selection (1):
         throw new Exception("Failed to load private API key", exception);
       }
 
+    }
+
+    static string TruncateString(string str, int maxLength = 2000)
+    {
+      if (string.IsNullOrEmpty(str))
+        return str;
+
+      return str.Length > maxLength ? string.Concat(str.AsSpan(0, maxLength), "...") : str;
     }
   }
 }

--- a/examples/dotnet/dotnet.csproj
+++ b/examples/dotnet/dotnet.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>IDE0003</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/nodejs/index.ts
+++ b/examples/nodejs/index.ts
@@ -101,18 +101,8 @@ async function runRetrieveDecryptAndConfirmFormSubmissions(
 
       console.info("Retrieving encrypted submission...");
 
-      const startGetFormSubmissionTimer = performance.now();
-
       const encryptedSubmission = await apiClient.getFormSubmission(
         newFormSubmission.name,
-      );
-
-      const endGetFormSubmissionTimer = performance.now();
-
-      console.info(
-        `\nForm submission retrieved in ${Math.round(
-          endGetFormSubmissionTimer - startGetFormSubmissionTimer,
-        )} ms`,
       );
 
       console.info("\nEncrypted submission:");

--- a/examples/python/data_structures.py
+++ b/examples/python/data_structures.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import List, Optional
 
 
 @dataclass
@@ -34,10 +35,10 @@ class NewFormSubmission:
 
 @dataclass
 class EncryptedFormSubmission:
-    encrypted_responses: str
     encrypted_key: str
     encrypted_nonce: str
     encrypted_auth_tag: str
+    encrypted_responses: str
 
     @staticmethod
     def from_json(json_object: dict) -> "EncryptedFormSubmission":
@@ -57,12 +58,28 @@ class FormSubmissionStatus(Enum):
 
 
 @dataclass
+class Attachment:
+    name: str
+    download_link: str
+    is_potentially_malicious: bool
+
+    @staticmethod
+    def from_json(json_object: dict) -> "Attachment":
+        return Attachment(
+            name=json_object["name"],
+            download_link=json_object["downloadLink"],
+            is_potentially_malicious=json_object["isPotentiallyMalicious"],
+        )
+
+
+@dataclass
 class FormSubmission:
     created_at: int
     status: FormSubmissionStatus
     confirmation_code: str
     answers: str
     checksum: str
+    attachments: Optional[List[Attachment]]
 
     @staticmethod
     def from_json(json_object: dict) -> "FormSubmission":
@@ -72,6 +89,11 @@ class FormSubmission:
             confirmation_code=json_object["confirmationCode"],
             answers=json_object["answers"],
             checksum=json_object["checksum"],
+            attachments=(
+                [Attachment.from_json(obj) for obj in json_object["attachments"]]
+                if json_object.get("attachments")
+                else None
+            ),
         )
 
 

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -1,7 +1,9 @@
 import json
 from pathlib import Path
+
+import requests
 from access_token_generator import AccessTokenGenerator
-from data_structures import PrivateApiKey, FormSubmission, FormSubmissionProblem
+from data_structures import Attachment, PrivateApiKey, FormSubmission, FormSubmissionProblem
 from gc_forms_api_client import GCFormsApiClient
 from form_submission_decrypter import FormSubmissionDecrypter
 from form_submission_integrity_verifier import FormSubmissionVerifier
@@ -12,132 +14,177 @@ GCFORMS_API_URL = "https://api.forms-formulaires.alpha.canada.ca"
 
 
 def main() -> None:
-    private_api_key = load_private_api_key()
+    try:
+        private_api_key = load_private_api_key()
 
-    menu_selection = input(
-        """
+        menu_selection = input(
+            """
 I want to:
 (1) Generate and display an access token
 (2) Retrieve, decrypt and confirm form submissions
 (3) Report a problem with a form submission
 Selection (1):
 """
+        )
+
+        match menu_selection:
+            case "2":
+                run_retrieve_decrypt_and_confirm_form_submissions(private_api_key)
+            case "3":
+                run_report_problem_with_form_submission(private_api_key)
+            case _:
+                run_generate_access_token(private_api_key)
+    except Exception as exception:
+            raise exception
+
+def run_generate_access_token(private_api_key: PrivateApiKey) -> None:
+    print("\nGenerating access token...")
+
+    access_token = AccessTokenGenerator.generate(
+        IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
     )
 
-    if menu_selection == "2":
-        print("\nGenerating access token...")
+    print("\nGenerated access token:")
+    print(access_token)
 
-        access_token = AccessTokenGenerator.generate(
-            IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
-        )
+def run_retrieve_decrypt_and_confirm_form_submissions(private_api_key: PrivateApiKey) -> None:
+    print("\nGenerating access token...")
 
-        api_client = GCFormsApiClient(
-            private_api_key.form_id, GCFORMS_API_URL, access_token
-        )
+    access_token = AccessTokenGenerator.generate(
+        IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
+    )
 
-        print("\nRetrieving form template...\n")
+    api_client = GCFormsApiClient(
+        private_api_key.form_id, GCFORMS_API_URL, access_token
+    )
 
-        form_template = api_client.get_form_template()
+    print("\nRetrieving form template...\n")
 
-        print(form_template)
+    form_template = api_client.get_form_template()
 
-        print("\nRetrieving new form submissions...")
+    print(truncate_string(json.dumps(form_template)))
 
-        new_form_submissions = api_client.get_new_form_submissions()
+    print("\nRetrieving new form submissions...")
 
-        if len(new_form_submissions) > 0:
-            print("\nNew form submissions:")
+    new_form_submissions = api_client.get_new_form_submissions()
 
-            print(", ".join(x.name for x in new_form_submissions))
+    if len(new_form_submissions) > 0:
+        print("\nNew form submissions:")
 
-            print("\nRetrieving, decrypting and confirming form submissions...")
+        print(", ".join(x.name for x in new_form_submissions))
 
-            for new_form_submission in new_form_submissions:
-                print(f"\nProcessing {new_form_submission.name}...\n")
+        print("\nRetrieving, decrypting and confirming form submissions...")
 
-                print("Retrieving encrypted submission...")
+        for new_form_submission in new_form_submissions:
+            print(f"\nProcessing {new_form_submission.name}...\n")
 
-                encrypted_submission = api_client.get_form_submission(
-                    new_form_submission.name
-                )
+            print("Retrieving encrypted submission...")
 
-                print("\nEncrypted submission:")
-                print(encrypted_submission.encrypted_responses)
+            encrypted_submission = api_client.get_form_submission(
+                new_form_submission.name
+            )
 
-                print("\nDecrypting submission...")
+            print("\nEncrypted submission:")
+            print(truncate_string(encrypted_submission.encrypted_responses))
 
-                decrypted_form_submission = FormSubmissionDecrypter.decrypt(
-                    encrypted_submission, private_api_key
-                )
+            print("\nDecrypting submission...")
 
-                print("\nDecrypted submission:")
-                print(decrypted_form_submission)
+            decrypted_form_submission = FormSubmissionDecrypter.decrypt(
+                encrypted_submission, private_api_key
+            )
 
-                form_submission = FormSubmission.from_json(
-                    json.loads(decrypted_form_submission)
-                )
+            print("\nDecrypted submission:")
+            print(truncate_string(decrypted_form_submission))
 
-                print("\nVerifying submission integrity...")
+            form_submission = FormSubmission.from_json(
+                json.loads(decrypted_form_submission)
+            )
 
-                integrity_verification_result = FormSubmissionVerifier.verify_integrity(
-                    form_submission.answers, form_submission.checksum
-                )
+            print("\nVerifying submission integrity...")
 
-                print(
-                    f"\nIntegrity verification result: {'OK' if integrity_verification_result else 'INVALID'}"
-                )
+            integrity_verification_result = FormSubmissionVerifier.verify_integrity(
+                form_submission.answers, form_submission.checksum
+            )
 
-                print("\nConfirming submission...")
+            print(
+                f"\nIntegrity verification result: {'OK' if integrity_verification_result else 'INVALID'}"
+            )
 
-                api_client.confirm_form_submission(
-                    new_form_submission.name, form_submission.confirmation_code
-                )
+            save_submission_locally(new_form_submission.name, form_submission)
 
-                print("\nSubmission confirmed")
+            print("\nConfirming submission...")
 
-                input(
-                    "\n=> Press any key to continue processing form submissions or Ctrl-C to exit"
-                )
-        else:
-            print("\nCould not find any new form submission!")
-    elif menu_selection == "3":
-        submission_name = input("\nSubmission name:\n")
+            api_client.confirm_form_submission(
+                new_form_submission.name, form_submission.confirmation_code
+            )
 
-        contact_email = input("\nContact email address:\n")
+            print("\nSubmission confirmed")
 
-        description = input("\nProblem description (10 characters minimum):\n")
-
-        preferred_language = input(
-            "\nPreferred communication language (either 'en' or 'fr'):\n"
-        )
-
-        print("\nGenerating access token...")
-
-        access_token = AccessTokenGenerator.generate(
-            IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
-        )
-
-        api_client = GCFormsApiClient(
-            private_api_key.form_id, GCFORMS_API_URL, access_token
-        )
-
-        print("\nReporting form submission...")
-
-        problem = FormSubmissionProblem(contact_email, description, preferred_language)
-
-        api_client.report_problem_with_form_submission(submission_name, problem)
-
-        print("\nSubmission has been reported")
+            input(
+                "\n=> Press any key to continue processing form submissions or Ctrl-C to exit"
+            )
     else:
-        print("\nGenerating access token...")
+        print("\nCould not find any new form submission!")
 
-        access_token = AccessTokenGenerator.generate(
-            IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
-        )
+def save_submission_locally(submission_name: str, submission: "FormSubmission") -> None:
+    print("\nSaving submission answers...")
 
-        print("\nGenerated access token:")
-        print(access_token)
+    submission_folder_path = Path("./") / submission_name
 
+    submission_folder_path.mkdir(parents=True, exist_ok=True)
+
+    with open(submission_folder_path / "answers.json", "w") as file:
+        file.write(submission.answers)
+
+    if submission.attachments:
+        print("\nSaving submission attachments...\n")
+
+        for attachment in submission.attachments:
+            download_and_save_attachment(attachment, submission_folder_path)
+
+    print(f"\nSubmission saved in folder named '{submission_folder_path}'")
+
+def download_and_save_attachment(attachment: Attachment, submission_folder_path: Path) -> None:
+    try:
+        response = requests.get(attachment.download_link, stream=True)
+        response.raise_for_status()
+
+        with open(submission_folder_path / attachment.name, "wb") as file:
+            for chunk in response.iter_content(chunk_size=8192):
+                file.write(chunk)
+
+        print(f"Submission attachment '{attachment.name}' has been saved {"(flagged as potentially malicious)" if attachment.is_potentially_malicious else ""}")
+    except Exception as e:
+        raise RuntimeError(f"Failed to download and save submission attachment {attachment.name}") from e
+
+def run_report_problem_with_form_submission(private_api_key: PrivateApiKey) -> None:
+    submission_name = input("\nSubmission name:\n")
+
+    contact_email = input("\nContact email address:\n")
+
+    description = input("\nProblem description (10 characters minimum):\n")
+
+    preferred_language = input(
+        "\nPreferred communication language (either 'en' or 'fr'):\n"
+    )
+
+    print("\nGenerating access token...")
+
+    access_token = AccessTokenGenerator.generate(
+        IDENTITY_PROVIDER_URL, PROJECT_IDENTIFIER, private_api_key
+    )
+
+    api_client = GCFormsApiClient(
+        private_api_key.form_id, GCFORMS_API_URL, access_token
+    )
+
+    print("\nReporting form submission...")
+
+    problem = FormSubmissionProblem(contact_email, description, preferred_language)
+
+    api_client.report_problem_with_form_submission(submission_name, problem)
+
+    print("\nSubmission has been reported")
 
 def load_private_api_key() -> PrivateApiKey:
     try:
@@ -152,6 +199,9 @@ def load_private_api_key() -> PrivateApiKey:
         )
     except Exception as exception:
         raise Exception("Failed to load private API key") from exception
+    
+def truncate_string(s: str, max_length: int = 2000) -> str:
+    return s[:max_length] + "..." if len(s) > max_length else s
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary | Résumé

- Adds support for submission attachments in all API integration examples
- Reworks some of the Bash scripts to make them compatible with the new `retrieve_save_confirm_form_submissions.sh` script that shows how to combine every smaller scripts to leverage all API features

List of examples:
- [x] [Node.JS / Typescript](https://github.com/cds-snc/forms-api/blob/main/examples/nodejs/accessTokenGenerator.ts)
- [x] [Python](https://github.com/cds-snc/forms-api/blob/main/examples/python/access_token_generator.py)
- [x] [.NET / C#](https://github.com/cds-snc/forms-api/blob/main/examples/dotnet/AccessTokenGenerator.cs)
- [x] [Bash / Curl](https://github.com/cds-snc/forms-api/blob/main/examples/bash/get_access_token.sh)