### PR TITLE
feature: Add ID to attachment object

### DIFF
--- a/src/lib/vault/mappers/formSubmission.mapper.ts
+++ b/src/lib/vault/mappers/formSubmission.mapper.ts
@@ -123,8 +123,7 @@ function partialAttachmentFromSubmissionAttachmentsAsJson(
     }
 
     if (
-      typeof item.id !== "string" ||
-      typeof item.id !== "undefined" ||
+      (typeof item.id !== "string" && typeof item.id !== "undefined") ||
       typeof item.name !== "string" ||
       typeof item.path !== "string" ||
       typeof item.scanStatus !== "string"

--- a/src/lib/vault/mappers/formSubmission.mapper.ts
+++ b/src/lib/vault/mappers/formSubmission.mapper.ts
@@ -123,6 +123,7 @@ function partialAttachmentFromSubmissionAttachmentsAsJson(
     }
 
     if (
+      typeof item.id !== "string" || typeof item.id !== "undefined" ||
       typeof item.name !== "string" ||
       typeof item.path !== "string" ||
       typeof item.scanStatus !== "string"
@@ -131,6 +132,7 @@ function partialAttachmentFromSubmissionAttachmentsAsJson(
     }
 
     return {
+      id: item.id,
       name: item.name,
       path: item.path,
       scanStatus: attachmentScanStatusFromScanStatus(item.scanStatus),

--- a/src/lib/vault/mappers/formSubmission.mapper.ts
+++ b/src/lib/vault/mappers/formSubmission.mapper.ts
@@ -123,7 +123,8 @@ function partialAttachmentFromSubmissionAttachmentsAsJson(
     }
 
     if (
-      typeof item.id !== "string" || typeof item.id !== "undefined" ||
+      typeof item.id !== "string" ||
+      typeof item.id !== "undefined" ||
       typeof item.name !== "string" ||
       typeof item.path !== "string" ||
       typeof item.scanStatus !== "string"

--- a/src/lib/vault/types/formSubmission.types.ts
+++ b/src/lib/vault/types/formSubmission.types.ts
@@ -18,6 +18,7 @@ export enum AttachmentScanStatus {
 }
 
 export type PartialAttachment = {
+  id: string;
   name: string;
   path: string;
   scanStatus: AttachmentScanStatus;

--- a/src/lib/vault/types/formSubmission.types.ts
+++ b/src/lib/vault/types/formSubmission.types.ts
@@ -17,8 +17,10 @@ export enum AttachmentScanStatus {
   Failed = "Failed",
 }
 
+// id is marked as optional to ensure backwards compatibility.
+// it can be marked as required in the future once we are sure all attachment responses contain id's
 export type PartialAttachment = {
-  id: string;
+  id?: string;
   name: string;
   path: string;
   scanStatus: AttachmentScanStatus;

--- a/src/operations/retrieveSubmission.v1.ts
+++ b/src/operations/retrieveSubmission.v1.ts
@@ -94,6 +94,7 @@ function buildJsonResponse(
     checksum: formSubmission.checksum,
     ...(attachments && {
       attachments: attachments.map((attachment) => ({
+        id: attachment.id,
         name: attachment.name,
         downloadLink: attachment.downloadLink,
         isPotentiallyMalicious: isAttachmentPotentiallyMalicious(

--- a/test/lib/vault/mappers/formSubmission.mapper.test.ts
+++ b/test/lib/vault/mappers/formSubmission.mapper.test.ts
@@ -5,7 +5,7 @@ import {
 import { AttachmentScanStatus } from "@lib/vault/types/formSubmission.types.js";
 import { describe, it, expect } from "vitest";
 
-describe("formSubmission mapper should", () => {
+describe("in formSubmission mapper", () => {
   describe("mapNewFormSubmissionFromDynamoDbResponse should", () => {
     it("return proper NewFormSubmission when DynamoDB response is complete and valid", () => {
       const newFormSubmission = mapNewFormSubmissionFromDynamoDbResponse({
@@ -47,6 +47,7 @@ describe("formSubmission mapper should", () => {
         FormSubmissionHash: "5981e9cd2a2f0032e9b8c99eb7bb8841",
         SubmissionAttachments: JSON.stringify([
           {
+            id: "testId",
             name: "output.txt",
             path: "filePath",
             scanStatus: "NO_THREATS_FOUND",
@@ -62,6 +63,41 @@ describe("formSubmission mapper should", () => {
         checksum: "5981e9cd2a2f0032e9b8c99eb7bb8841",
         attachments: [
           {
+            id: "testId",
+            name: "output.txt",
+            path: "filePath",
+            scanStatus: AttachmentScanStatus.NoThreatsFound,
+          },
+        ],
+      });
+    });
+
+    // This test should be deleted once `PartialAttachment` has its `id` property set to non optional
+    it("return proper FormSubmission when DynamoDB response is complete and valid (testing backwards compatibility with file attachments not having defined 'id')", () => {
+      const formSubmission = mapFormSubmissionFromDynamoDbResponse({
+        CreatedAt: 1750263415913,
+        "Status#CreatedAt": "New#1750263415913",
+        ConfirmationCode: "99063d75-9804-4efa-8f4c-605b4ba6ad95",
+        FormSubmission: '{"1":"Test response"}',
+        FormSubmissionHash: "5981e9cd2a2f0032e9b8c99eb7bb8841",
+        SubmissionAttachments: JSON.stringify([
+          {
+            name: "output.txt",
+            path: "filePath",
+            scanStatus: "NO_THREATS_FOUND",
+          },
+        ]),
+      });
+
+      expect(formSubmission).toEqual({
+        createdAt: 1750263415913,
+        status: "New",
+        confirmationCode: "99063d75-9804-4efa-8f4c-605b4ba6ad95",
+        answers: '{"1":"Test response"}',
+        checksum: "5981e9cd2a2f0032e9b8c99eb7bb8841",
+        attachments: [
+          {
+            id: undefined,
             name: "output.txt",
             path: "filePath",
             scanStatus: AttachmentScanStatus.NoThreatsFound,

--- a/test/operations/retrieveSubmission.v1.test.ts
+++ b/test/operations/retrieveSubmission.v1.test.ts
@@ -109,7 +109,6 @@ describe("retrieveSubmissionOperation handler should", () => {
       checksum: "",
       attachments: [
         {
-          id: "testId",
           name: "output.txt",
           path: "form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt",
           scanStatus: AttachmentScanStatus.NoThreatsFound,
@@ -248,6 +247,7 @@ describe("retrieveSubmissionOperation handler should", () => {
           checksum: "",
           attachments: [
             {
+              id: "testId",
               name: "output.txt",
               downloadLink: "https://download-link",
               isPotentiallyMalicious,

--- a/test/operations/retrieveSubmission.v1.test.ts
+++ b/test/operations/retrieveSubmission.v1.test.ts
@@ -109,6 +109,7 @@ describe("retrieveSubmissionOperation handler should", () => {
       checksum: "",
       attachments: [
         {
+          id: "testId",
           name: "output.txt",
           path: "form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt",
           scanStatus: AttachmentScanStatus.NoThreatsFound,
@@ -218,6 +219,7 @@ describe("retrieveSubmissionOperation handler should", () => {
         checksum: "",
         attachments: [
           {
+            id: "testId",
             name: "output.txt",
             path: "form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt",
             scanStatus: attachmentScanStatus,
@@ -266,6 +268,7 @@ describe("retrieveSubmissionOperation handler should", () => {
       checksum: "",
       attachments: [
         {
+          id: "testId",
           name: "output.txt",
           path: "form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt",
           scanStatus: AttachmentScanStatus.NoThreatsFound,

--- a/test/operations/retrieveSubmission.v1.test.ts
+++ b/test/operations/retrieveSubmission.v1.test.ts
@@ -109,6 +109,7 @@ describe("retrieveSubmissionOperation handler should", () => {
       checksum: "",
       attachments: [
         {
+          id: "testId",
           name: "output.txt",
           path: "form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt",
           scanStatus: AttachmentScanStatus.NoThreatsFound,
@@ -151,6 +152,7 @@ describe("retrieveSubmissionOperation handler should", () => {
         checksum: "",
         attachments: [
           {
+            id: "testId",
             name: "output.txt",
             downloadLink: "https://download-link",
             isPotentiallyMalicious: false,
@@ -167,6 +169,61 @@ describe("retrieveSubmissionOperation handler should", () => {
         type: "Response",
       },
       "DownloadResponse",
+    );
+  });
+
+  // This test should be deleted once `PartialAttachment` has its `id` property set to non optional
+  it("respond with success when form submission with attachments does exist (testing backwards compatibility with file attachments not having defined 'id')", async () => {
+    getFormSubmissionMock.mockResolvedValueOnce({
+      createdAt: 0,
+      status: SubmissionStatus.New,
+      confirmationCode: "",
+      answers:
+        '{"1":"Test1","2":"form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt}',
+      checksum: "",
+      attachments: [
+        {
+          name: "output.txt",
+          path: "form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt",
+          scanStatus: AttachmentScanStatus.NoThreatsFound,
+        },
+      ],
+    });
+    getFormSubmissionAttachmentDownloadLinkMock.mockResolvedValueOnce(
+      "https://download-link",
+    );
+    getPublicKeyMock.mockResolvedValueOnce("publicKey");
+    encryptResponseMock.mockReturnValueOnce({
+      encryptedKey: "encryptedKey",
+      encryptedNonce: "encryptedNonce",
+      encryptedAuthTag: "encryptedAuthTag",
+      encryptedResponses: "encryptedResponses",
+    });
+
+    await retrieveSubmissionOperationV1.handler(
+      requestMock,
+      responseMock,
+      nextMock,
+    );
+
+    expect(encryptResponseMock).toHaveBeenCalledWith(
+      "publicKey",
+      JSON.stringify({
+        createdAt: 0,
+        status: "New",
+        confirmationCode: "",
+        answers:
+          '{"1":"Test1","2":"form_attachments/2025-06-09/8b42aafd-09e9-44ad-9208-d3891a7858df/output.txt}',
+        checksum: "",
+        attachments: [
+          {
+            id: undefined,
+            name: "output.txt",
+            downloadLink: "https://download-link",
+            isPotentiallyMalicious: false,
+          },
+        ],
+      }),
     );
   });
 


### PR DESCRIPTION
# Summary | Résumé
Adds attachment ID to the object so that it is easier to identify to which form response it corresponds.