### PR TITLE
chore: fix Slack notification when Github workflow fails

### DIFF
--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -19,5 +19,5 @@ jobs:
     steps:
       - name: Notify Slack
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Forms API workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          json='{"text":":x: GCForms API deployment failed.\n<${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ env.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
# Summary | Résumé

- Fixes Slack notification when Github workflow fails (this is due to the recent SRE Bot integration work)

Note: will update SLACK webhooks in repo secrets before merging.