### PR TITLE
chore: use new StatusCreatedAt_v2 index

### DIFF
--- a/src/lib/vault/getNewFormSubmissions.ts
+++ b/src/lib/vault/getNewFormSubmissions.ts
@@ -17,7 +17,7 @@ export async function getNewFormSubmissions(
         await AwsServicesConnector.getInstance().dynamodbClient.send(
           new QueryCommand({
             TableName: "Vault",
-            IndexName: "StatusCreatedAt",
+            IndexName: "StatusCreatedAt_v2",
             ExclusiveStartKey: lastEvaluatedKey ?? undefined,
             Limit: limit - newFormSubmissions.length,
             KeyConditionExpression:


### PR DESCRIPTION
# Summary | Résumé

- Replaces old `StatusCreatedAt` with `StatusCreatedAt_v2` DynamoDB Vault table index

Note: we have to make sure we release infra to Production before this change is also released