### PR TITLE
chore: pnpm upgrade

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,6 @@
     }
   },
   "appPort": [3001],
-  "postCreateCommand": "npm i -g corepack@latest && corepack enable pnpm && pnpm config set store-dir /home/vscode/pnpm/store && corepack use pnpm@10.25.0 && pnpm install",
+  "postCreateCommand": "npm i -g corepack@latest && corepack enable pnpm && pnpm config set store-dir /home/vscode/pnpm/store && corepack use pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26 && pnpm install",
   "remoteUser": "vscode"
 }

--- a/.github/workflows/backstage-catalog-helper.yml
+++ b/.github/workflows/backstage-catalog-helper.yml
@@ -17,7 +17,7 @@ jobs:
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
           DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
       - name: Checkout Actions
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -38,10 +38,10 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token}}
           sign-commits: true
-          commit-message: 'Add catalog-info.yaml'
-          branch: 'backstage/catalog-info'
-          title: 'Add catalog-info.yaml'
-          body: 'Adding a basic catalog-info.yaml to start populating the backstage catalog with your components.'
-          labels: 'backstage'
+          commit-message: "Add catalog-info.yaml"
+          branch: "backstage/catalog-info"
+          title: "Add catalog-info.yaml"
+          body: "Adding a basic catalog-info.yaml to start populating the backstage catalog with your components."
+          labels: "backstage"
           add-paths: |
             catalog-info.yaml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Dependency review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/export_github_data.yml
+++ b/.github/workflows/export_github_data.yml
@@ -21,7 +21,7 @@ jobs:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
           DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -30,7 +30,7 @@ jobs:
           DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -12,34 +12,34 @@ jobs:
   s3-backup:
     runs-on: ubuntu-latest
     steps:
-    - name: Audit DNS requests
-      uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # v1.0.2
-      env:
-        DNS_PROXY_FORWARDTOSENTINEL: "true"
-        DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
-        DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+      - name: Audit DNS requests
+        uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # v1.0.2
+        env:
+          DNS_PROXY_FORWARDTOSENTINEL: "true"
+          DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
-    - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        fetch-depth: 0 # retrieve all history
-        persist-credentials: false
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # retrieve all history
+          persist-credentials: false
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
-      with:
-        role-to-assume: ${{ secrets.AWS_S3_BACKUP_IAM_ROLE_ARN }}
-        role-session-name: S3Backup
-        aws-region: ca-central-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_BACKUP_IAM_ROLE_ARN }}
+          role-session-name: S3Backup
+          aws-region: ca-central-1
 
-    - name: Upload zip to S3 bucket
-      run: |
-        ZIP_FILE=`basename ${{ github.repository }}`-`date '+%Y-%m-%d'`.zip
-        zip -rq "${ZIP_FILE}" .
-        aws s3 cp "${ZIP_FILE}" s3://${{ secrets.AWS_S3_BACKUP_BUCKET }}/${{ github.repository }}/"${ZIP_FILE}"
+      - name: Upload zip to S3 bucket
+        run: |
+          ZIP_FILE=`basename ${{ github.repository }}`-`date '+%Y-%m-%d'`.zip
+          zip -rq "${ZIP_FILE}" .
+          aws s3 cp "${ZIP_FILE}" s3://${{ secrets.AWS_S3_BACKUP_BUCKET }}/${{ github.repository }}/"${ZIP_FILE}"
 
-    - name: Notify Slack channel if this job failed
-      if: ${{ failure() }}
-      run: |
-        json='{"text":"S3 backup failed in <https://github.com/${{ github.repository }}>!"}'
-        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_NOTIFY_WEBHOOK }}
+      - name: Notify Slack channel if this job failed
+        if: ${{ failure() }}
+        run: |
+          json='{"text":"S3 backup failed in <https://github.com/${{ github.repository }}>!"}'
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_NOTIFY_WEBHOOK }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -8,7 +8,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Shellcheck
         run: |
           .github/workflows/scripts/run-shellcheck.sh

--- a/.github/workflows/staging-post-deployment.yml
+++ b/.github/workflows/staging-post-deployment.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build Docker image
         run: docker build --platform=linux/amd64 --provenance false -t forms-api .

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -12,13 +12,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: "22.22.3"
-
-      - name: PNPM update to v10.25.0
-        run: npm i -g corepack@latest && corepack enable pnpm && corepack use pnpm@10.25.0
+      - name: PNPM update to v11.8.0
+        run: npm i -g corepack@latest && corepack enable pnpm && corepack use pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: PNPM update to v11.8.0
         run: npm i -g corepack@latest && corepack enable pnpm && corepack use pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -18,15 +18,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Format
-        run: pnpm format:check
-
-      - name: Lint:report
-        continue-on-error: true
-        run: pnpm lint:github
-
-      - name: Lint
-        run: pnpm lint:check
-
       - name: Test
         run: pnpm test
+
+      - name: Check code
+        run: pnpm code:check

--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build Docker image
         run: docker build --platform=linux/amd64 --provenance false -t forms/api .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,16 @@
 {
   "editor.defaultFormatter": "biomejs.biome",
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-  "typescript.validate.enable": true,
-  "typescript.tsserver.experimental.enableProjectDiagnostics": true,
-  "typescript.preferences.importModuleSpecifier": "shortest",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  "js/ts.validate.enabled": true,
+  "js/ts.tsserver.experimental.enableProjectDiagnostics": true,
+  "js/ts.preferences.importModuleSpecifier": "shortest",
   "editor.formatOnSave": true,
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports.biome": "explicit"
+    }
   },
   "[csharp]": {
     "editor.defaultFormatter": "ms-dotnettools.csharp"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG NODE_VERSION=22.22.3-alpine3.23@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920
-ARG PNPM_VERSION=10.25.0
+ARG PNPM_VERSION=11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26
 
 FROM node:$NODE_VERSION AS build
 ARG PNPM_VERSION
 
 WORKDIR /src
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 RUN npm i -g corepack@latest &&\
     corepack enable pnpm &&\
@@ -23,7 +23,7 @@ ENV NODE_ENV=production
 
 WORKDIR /src
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY --from=build /src/node_modules ./node_modules
 COPY --from=build /src/build ./build
 

--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,9 @@
       "**/build/**",
       "node_modules/**",
       "package.json",
-      "pnpm-lock.yaml"
+      "pnpm-lock.yaml",
+      "documentation/**",
+      "examples/**"
     ]
   },
   "organizeImports": {

--- a/examples/nodejs/accessTokenGenerator.ts
+++ b/examples/nodejs/accessTokenGenerator.ts
@@ -1,6 +1,6 @@
 import { createPrivateKey } from "node:crypto";
-import { SignJWT } from "jose";
 import axios from "axios";
+import { SignJWT } from "jose";
 import type { PrivateApiKey } from "./types.js";
 
 export function generateAccessToken(

--- a/examples/nodejs/formSubmissionDecrypter.ts
+++ b/examples/nodejs/formSubmissionDecrypter.ts
@@ -1,4 +1,4 @@
-import { privateDecrypt, createDecipheriv } from "node:crypto";
+import { createDecipheriv, privateDecrypt } from "node:crypto";
 import type { EncryptedFormSubmission, PrivateApiKey } from "./types.js";
 
 export function decryptFormSubmission(

--- a/examples/nodejs/index.ts
+++ b/examples/nodejs/index.ts
@@ -1,19 +1,19 @@
+import { createWriteStream } from "node:fs";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 import readline from "node:readline";
+import type { Readable } from "node:stream";
+import axios from "axios";
+import { generateAccessToken } from "./accessTokenGenerator.js";
+import { decryptFormSubmission } from "./formSubmissionDecrypter.js";
+import { verifyIntegrity } from "./formSubmissionIntegrityVerifier.js";
+import { GCFormsApiClient } from "./gcFormsApiClient.js";
 import type {
   Attachment,
   FormSubmission,
   FormSubmissionProblem,
   PrivateApiKey,
 } from "./types.js";
-import { generateAccessToken } from "./accessTokenGenerator.js";
-import { GCFormsApiClient } from "./gcFormsApiClient.js";
-import { decryptFormSubmission } from "./formSubmissionDecrypter.js";
-import { verifyIntegrity } from "./formSubmissionIntegrityVerifier.js";
-import path from "node:path";
-import { createWriteStream } from "node:fs";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import axios from "axios";
-import type { Readable } from "node:stream";
 
 const IDENTITY_PROVIDER_URL = "https://auth.forms-formulaires.alpha.canada.ca";
 const PROJECT_IDENTIFIER = "284778202772022819";

--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "vitest-mock-express": "^2.2.0",
     "vitest-mock-extended": "^4.0.0"
   },
-  "packageManager": "pnpm@10.34.1"
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26"
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "start": "node build/server.js",
     "dev": "tsx watch --ignore \"./utils/**/*\" --ignore \"./test/**/*\" --ignore \"./build/**/*\" src/server.ts",
     "test": "vitest run",
-    "lint": "biome lint --write --diagnostic-level=warn .",
-    "lint:github": "biome ci --reporter=github .",
-    "lint:check": "biome lint --error-on-warnings --diagnostic-level=warn .",
-    "format": "biome format --write .",
-    "format:check": "biome format ."
+    "code:check": "biome check --error-on-warnings --diagnostic-level=warn .",
+    "code:lint": "biome lint --write --diagnostic-level=warn .",
+    "code:format": "biome format --write ."
   },
   "keywords": [],
   "author": "Canadian Digital Service",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@biomejs/biome': false
+  esbuild: false

--- a/src/lib/encryption/encryptResponse.ts
+++ b/src/lib/encryption/encryptResponse.ts
@@ -1,8 +1,8 @@
 import {
-  randomBytes,
   createCipheriv,
   createPublicKey,
   publicEncrypt,
+  randomBytes,
 } from "node:crypto";
 import { logMessage } from "@lib/logging/logger.js";
 

--- a/src/lib/idp/verifyAccessToken.ts
+++ b/src/lib/idp/verifyAccessToken.ts
@@ -1,11 +1,11 @@
-import { introspectAccessToken } from "@lib/integration/zitadelConnector.js";
-import {
-  setValueInRedis,
-  getValueFromRedis,
-} from "@lib/integration/redis/redisClientAdapter.js";
 import { createHash } from "node:crypto";
-import { logMessage } from "@lib/logging/logger.js";
+import {
+  getValueFromRedis,
+  setValueInRedis,
+} from "@lib/integration/redis/redisClientAdapter.js";
+import { introspectAccessToken } from "@lib/integration/zitadelConnector.js";
 import { auditLog } from "@lib/logging/auditLogs.js";
+import { logMessage } from "@lib/logging/logger.js";
 
 export type VerifiedAccessToken = {
   expirationEpochTime: number;

--- a/src/lib/integration/awsServicesConnector.ts
+++ b/src/lib/integration/awsServicesConnector.ts
@@ -1,8 +1,8 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
-import { SQSClient } from "@aws-sdk/client-sqs";
-import { AWS_REGION } from "@config";
 import { S3Client } from "@aws-sdk/client-s3";
+import { SQSClient } from "@aws-sdk/client-sqs";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { AWS_REGION } from "@config";
 
 const globalConfig = {
   region: AWS_REGION,

--- a/src/lib/integration/awsSqsQueueLoader.ts
+++ b/src/lib/integration/awsSqsQueueLoader.ts
@@ -1,5 +1,5 @@
-import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
 import { GetQueueUrlCommand } from "@aws-sdk/client-sqs";
+import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
 import { logMessage } from "@lib/logging/logger.js";
 
 let apiAuditLogSqsQueueUrl: string | null = null;

--- a/src/lib/integration/freshdeskConnector.ts
+++ b/src/lib/integration/freshdeskConnector.ts
@@ -1,6 +1,6 @@
-import got from "got";
 import { FRESHDESK_API_KEY, FRESHDESK_API_URL } from "@config";
 import { logMessage } from "@lib/logging/logger.js";
+import got from "got";
 
 export type FreshdeskTicketPayload = {
   name: string;

--- a/src/lib/integration/redis/redisConnector.ts
+++ b/src/lib/integration/redis/redisConnector.ts
@@ -1,6 +1,6 @@
-import { type RedisClientType, createClient } from "redis";
 import { REDIS_URL } from "@config";
 import { logMessage } from "@lib/logging/logger.js";
+import { type RedisClientType, createClient } from "redis";
 
 export class RedisConnector {
   private static instance: RedisConnector | undefined = undefined;

--- a/src/lib/integration/zitadelConnector.ts
+++ b/src/lib/integration/zitadelConnector.ts
@@ -1,4 +1,3 @@
-import { SignJWT } from "jose";
 import { createPrivateKey } from "node:crypto";
 import {
   ZITADEL_APPLICATION_KEY,
@@ -7,6 +6,7 @@ import {
 } from "@config";
 import { logMessage } from "@lib/logging/logger.js";
 import got from "got";
+import { SignJWT } from "jose";
 
 export type AccessTokenIntrospectionResult = {
   active: boolean;

--- a/src/lib/logging/auditLogs.ts
+++ b/src/lib/logging/auditLogs.ts
@@ -1,8 +1,8 @@
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
+import { ENVIRONMENT_MODE, EnvironmentMode } from "@config";
 import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
 import { getApiAuditLogSqsQueueUrl } from "@lib/integration/awsSqsQueueLoader.js";
 import { logMessage } from "@lib/logging/logger.js";
-import { EnvironmentMode, ENVIRONMENT_MODE } from "@config";
 import {
   RequestContextualStoreKey,
   retrieveRequestContextData,

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -1,5 +1,5 @@
+import { ENVIRONMENT_MODE, EnvironmentMode } from "@config";
 import pino from "pino";
-import { EnvironmentMode, ENVIRONMENT_MODE } from "@config";
 
 export const logMessage = pino({
   level: ENVIRONMENT_MODE === EnvironmentMode.local ? "debug" : "info",

--- a/src/lib/rateLimiting/tokenBucketProvider.ts
+++ b/src/lib/rateLimiting/tokenBucketProvider.ts
@@ -1,15 +1,15 @@
 import {
-  type RateLimiterAbstract,
-  RateLimiterMemory,
-  RateLimiterRedis,
-} from "rate-limiter-flexible";
-import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
-import {
   highRateLimiterConfiguration,
   lowRateLimiterConfiguration,
 } from "@config";
 import { getValueFromRedis } from "@lib/integration/redis/redisClientAdapter.js";
+import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
 import { logMessage } from "@lib/logging/logger.js";
+import {
+  type RateLimiterAbstract,
+  RateLimiterMemory,
+  RateLimiterRedis,
+} from "rate-limiter-flexible";
 
 const REDIS_RATE_LIMIT_KEY_PREFIX: string = "rate-limit";
 

--- a/src/lib/vault/confirmFormSubmission.ts
+++ b/src/lib/vault/confirmFormSubmission.ts
@@ -1,12 +1,12 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
+import { logMessage } from "@lib/logging/logger.js";
+import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
 import {
   FormSubmissionAlreadyConfirmedException,
   FormSubmissionIncorrectConfirmationCodeException,
 } from "@lib/vault/types/exceptions.types.js";
 import { SubmissionStatus } from "@lib/vault/types/formSubmission.types.js";
-import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
-import { logMessage } from "@lib/logging/logger.js";
 
 const REMOVAL_DATE_DELAY_IN_DAYS = 30;
 

--- a/src/lib/vault/getFormSubmission.ts
+++ b/src/lib/vault/getFormSubmission.ts
@@ -1,9 +1,9 @@
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
 import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
-import type { FormSubmission } from "@lib/vault/types/formSubmission.types.js";
 import { logMessage } from "@lib/logging/logger.js";
-import { FormSubmissionNotFoundException } from "@lib/vault/types/exceptions.types.js";
 import { mapFormSubmissionFromDynamoDbResponse } from "@lib/vault/mappers/formSubmission.mapper.js";
+import { FormSubmissionNotFoundException } from "@lib/vault/types/exceptions.types.js";
+import type { FormSubmission } from "@lib/vault/types/formSubmission.types.js";
 
 export async function getFormSubmission(
   formId: string,

--- a/src/lib/vault/getFormSubmissionAttachmentDownloadLink.ts
+++ b/src/lib/vault/getFormSubmissionAttachmentDownloadLink.ts
@@ -1,7 +1,7 @@
-import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
 import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { VAULT_FILE_STORAGE_BUCKET_NAME } from "@config";
+import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
 import { logMessage } from "@lib/logging/logger.js";
 
 export function getFormSubmissionAttachmentDownloadLink(

--- a/src/lib/vault/getNewFormSubmissions.ts
+++ b/src/lib/vault/getNewFormSubmissions.ts
@@ -1,8 +1,8 @@
 import { QueryCommand, type QueryCommandOutput } from "@aws-sdk/lib-dynamodb";
 import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
-import type { NewFormSubmission } from "@lib/vault/types/formSubmission.types.js";
 import { logMessage } from "@lib/logging/logger.js";
 import { mapNewFormSubmissionFromDynamoDbResponse } from "@lib/vault/mappers/formSubmission.mapper.js";
+import type { NewFormSubmission } from "@lib/vault/types/formSubmission.types.js";
 
 export async function getNewFormSubmissions(
   formId: string,

--- a/src/lib/vault/mappers/formSubmission.mapper.ts
+++ b/src/lib/vault/mappers/formSubmission.mapper.ts
@@ -1,10 +1,10 @@
 import { logMessage } from "@lib/logging/logger.js";
 import {
-  type NewFormSubmission,
-  type FormSubmission,
-  SubmissionStatus,
-  type PartialAttachment,
   AttachmentScanStatus,
+  type FormSubmission,
+  type NewFormSubmission,
+  type PartialAttachment,
+  SubmissionStatus,
 } from "@lib/vault/types/formSubmission.types.js";
 
 export function mapNewFormSubmissionFromDynamoDbResponse(

--- a/src/lib/vault/reportProblemWithFormSubmission.ts
+++ b/src/lib/vault/reportProblemWithFormSubmission.ts
@@ -1,9 +1,9 @@
 import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { AwsServicesConnector } from "@lib/integration/awsServicesConnector.js";
+import { logMessage } from "@lib/logging/logger.js";
+import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
 import { FormSubmissionAlreadyReportedAsProblematicException } from "@lib/vault/types/exceptions.types.js";
 import { SubmissionStatus } from "@lib/vault/types/formSubmission.types.js";
-import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
-import { logMessage } from "@lib/logging/logger.js";
 
 export async function reportProblemWithFormSubmission(
   formId: string,

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -1,15 +1,15 @@
-import type { NextFunction, Request, Response } from "express";
 import {
-  verifyAccessToken,
+  AccessControlError,
   AccessTokenExpiredError,
   AccessTokenInvalidError,
-  AccessControlError,
   AccessTokenMalformedError,
+  verifyAccessToken,
 } from "@lib/idp/verifyAccessToken.js";
 import {
   RequestContextualStoreKey,
   saveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import type { NextFunction, Request, Response } from "express";
 
 export async function authenticationMiddleware(
   request: Request,

--- a/src/middleware/extractClientIp.ts
+++ b/src/middleware/extractClientIp.ts
@@ -1,9 +1,9 @@
-import type { NextFunction, Request, Response } from "express";
+import type { IncomingHttpHeaders } from "node:http";
 import {
   RequestContextualStoreKey,
   saveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
-import type { IncomingHttpHeaders } from "node:http";
+import type { NextFunction, Request, Response } from "express";
 
 const FALLBACK_CLIENT_IP_ADDRESS = "0.0.0.0";
 

--- a/src/middleware/globalErrorHandler.ts
+++ b/src/middleware/globalErrorHandler.ts
@@ -1,10 +1,10 @@
-import type { Request, Response, NextFunction } from "express";
 import { logMessage } from "@lib/logging/logger.js";
 import { refundConsumedToken } from "@lib/rateLimiting/tokenBucketLimiter.js";
 import {
   RequestContextualStoreKey,
   retrieveOptionalRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import type { NextFunction, Request, Response } from "express";
 
 export async function globalErrorHandlerMiddleware(
   error: Error,

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -1,12 +1,12 @@
-import type { NextFunction, Request, Response } from "express";
-import { consumeTokenIfAvailable } from "@lib/rateLimiting/tokenBucketLimiter.js";
-import { logMessage } from "@lib/logging/logger.js";
 import { auditLog } from "@lib/logging/auditLogs.js";
+import { logMessage } from "@lib/logging/logger.js";
+import { consumeTokenIfAvailable } from "@lib/rateLimiting/tokenBucketLimiter.js";
 import {
   RequestContextualStoreKey,
   retrieveRequestContextData,
   saveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import type { NextFunction, Request, Response } from "express";
 
 export async function rateLimiterMiddleware(
   request: Request,

--- a/src/middleware/requestContext.ts
+++ b/src/middleware/requestContext.ts
@@ -1,5 +1,5 @@
-import type { NextFunction, Request, Response } from "express";
 import { requestContextualStore } from "@lib/storage/requestContextualStore.js";
+import type { NextFunction, Request, Response } from "express";
 
 export function requestContextMiddleware(
   _: Request,

--- a/src/middleware/requestValidator.ts
+++ b/src/middleware/requestValidator.ts
@@ -1,9 +1,9 @@
 import type { NextFunction, Request, Response } from "express";
 import {
-  checkSchema,
   type Location,
-  validationResult,
   type Schema,
+  checkSchema,
+  validationResult,
 } from "express-validator";
 
 export function requestValidatorMiddleware(

--- a/src/middleware/version.ts
+++ b/src/middleware/version.ts
@@ -1,5 +1,5 @@
-import type { NextFunction, Request, Response } from "express";
 import { logMessage } from "@lib/logging/logger.js";
+import type { NextFunction, Request, Response } from "express";
 
 export const versionMiddleware = (version: number) => {
   return (req: Request, _: Response, next: NextFunction) => {

--- a/src/operations/checkServiceHealth.ts
+++ b/src/operations/checkServiceHealth.ts
@@ -1,5 +1,5 @@
-import type { Request, Response } from "express";
 import type { ApiOperation } from "@operations/types/operation.js";
+import type { Request, Response } from "express";
 
 function main(_: Request, response: Response): void {
   response.json({

--- a/src/operations/confirmSubmission.v1.ts
+++ b/src/operations/confirmSubmission.v1.ts
@@ -1,16 +1,16 @@
-import type { NextFunction, Request, Response } from "express";
-import {
-  FormSubmissionAlreadyConfirmedException,
-  FormSubmissionNotFoundException,
-  FormSubmissionIncorrectConfirmationCodeException,
-} from "@lib/vault/types/exceptions.types.js";
-import { confirmFormSubmission } from "@lib/vault/confirmFormSubmission.js";
 import { auditLog } from "@lib/logging/auditLogs.js";
-import type { ApiOperation } from "@operations/types/operation.js";
 import {
   RequestContextualStoreKey,
   retrieveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import { confirmFormSubmission } from "@lib/vault/confirmFormSubmission.js";
+import {
+  FormSubmissionAlreadyConfirmedException,
+  FormSubmissionIncorrectConfirmationCodeException,
+  FormSubmissionNotFoundException,
+} from "@lib/vault/types/exceptions.types.js";
+import type { ApiOperation } from "@operations/types/operation.js";
+import type { NextFunction, Request, Response } from "express";
 
 async function v1(
   request: Request,

--- a/src/operations/reportSubmission.v1.ts
+++ b/src/operations/reportSubmission.v1.ts
@@ -1,24 +1,24 @@
+import { ENVIRONMENT_MODE, EnvironmentMode } from "@config";
+import { auditLog } from "@lib/logging/auditLogs.js";
+import { logMessage } from "@lib/logging/logger.js";
+import {
+  RequestContextualStoreKey,
+  retrieveRequestContextData,
+} from "@lib/storage/requestContextualStore.js";
+import { notifySupportAboutFormSubmissionProblem } from "@lib/support/notifySupportAboutFormSubmissionProblem.js";
+import { reportProblemWithFormSubmission } from "@lib/vault/reportProblemWithFormSubmission.js";
+import {
+  FormSubmissionAlreadyReportedAsProblematicException,
+  FormSubmissionNotFoundException,
+} from "@lib/vault/types/exceptions.types.js";
+import { requestValidatorMiddleware } from "@middleware/requestValidator.js";
+import type { ApiOperation } from "@operations/types/operation.js";
 import express, {
   type NextFunction,
   type Request,
   type Response,
 } from "express";
-import { ENVIRONMENT_MODE, EnvironmentMode } from "@config";
 import type { Schema } from "express-validator";
-import { requestValidatorMiddleware } from "@middleware/requestValidator.js";
-import {
-  FormSubmissionAlreadyReportedAsProblematicException,
-  FormSubmissionNotFoundException,
-} from "@lib/vault/types/exceptions.types.js";
-import { reportProblemWithFormSubmission } from "@lib/vault/reportProblemWithFormSubmission.js";
-import { notifySupportAboutFormSubmissionProblem } from "@lib/support/notifySupportAboutFormSubmissionProblem.js";
-import { logMessage } from "@lib/logging/logger.js";
-import { auditLog } from "@lib/logging/auditLogs.js";
-import type { ApiOperation } from "@operations/types/operation.js";
-import {
-  RequestContextualStoreKey,
-  retrieveRequestContextData,
-} from "@lib/storage/requestContextualStore.js";
 
 const validationSchema: Schema = {
   contactEmail: {

--- a/src/operations/retrieveNewSubmissions.v1.ts
+++ b/src/operations/retrieveNewSubmissions.v1.ts
@@ -1,12 +1,12 @@
-import type { NextFunction, Request, Response } from "express";
-import { getNewFormSubmissions } from "@lib/vault/getNewFormSubmissions.js";
 import { auditLog } from "@lib/logging/auditLogs.js";
-import type { ApiOperation } from "@operations/types/operation.js";
-import type { NewFormSubmission } from "@lib/vault/types/formSubmission.types.js";
 import {
   RequestContextualStoreKey,
   retrieveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import { getNewFormSubmissions } from "@lib/vault/getNewFormSubmissions.js";
+import type { NewFormSubmission } from "@lib/vault/types/formSubmission.types.js";
+import type { ApiOperation } from "@operations/types/operation.js";
+import type { NextFunction, Request, Response } from "express";
 
 const MAXIMUM_NUMBER_OF_RETURNED_NEW_FORM_SUBMISSIONS: number = 100;
 

--- a/src/operations/retrieveSubmission.v1.ts
+++ b/src/operations/retrieveSubmission.v1.ts
@@ -1,20 +1,20 @@
-import type { NextFunction, Request, Response } from "express";
-import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
 import { encryptResponse } from "@lib/encryption/encryptResponse.js";
-import { auditLog } from "@lib/logging/auditLogs.js";
-import type { ApiOperation } from "@operations/types/operation.js";
-import { FormSubmissionNotFoundException } from "@lib/vault/types/exceptions.types.js";
-import { getFormSubmissionAttachmentDownloadLink } from "@lib/vault/getFormSubmissionAttachmentDownloadLink.js";
 import { getPublicKey } from "@lib/formsClient/getPublicKey.js";
+import { auditLog } from "@lib/logging/auditLogs.js";
+import {
+  RequestContextualStoreKey,
+  retrieveRequestContextData,
+} from "@lib/storage/requestContextualStore.js";
+import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
+import { getFormSubmissionAttachmentDownloadLink } from "@lib/vault/getFormSubmissionAttachmentDownloadLink.js";
+import { FormSubmissionNotFoundException } from "@lib/vault/types/exceptions.types.js";
 import {
   AttachmentScanStatus,
   type FormSubmission,
   type PartialAttachment,
 } from "@lib/vault/types/formSubmission.types.js";
-import {
-  RequestContextualStoreKey,
-  retrieveRequestContextData,
-} from "@lib/storage/requestContextualStore.js";
+import type { ApiOperation } from "@operations/types/operation.js";
+import type { NextFunction, Request, Response } from "express";
 
 type CompleteAttachment = PartialAttachment & {
   downloadLink: string;

--- a/src/operations/retrieveTemplate.v1.ts
+++ b/src/operations/retrieveTemplate.v1.ts
@@ -1,12 +1,12 @@
-import type { NextFunction, Request, Response } from "express";
 import { getFormTemplate } from "@lib/formsClient/getFormTemplate.js";
-import { auditLog } from "@lib/logging/auditLogs.js";
-import type { ApiOperation } from "@operations/types/operation.js";
 import type { FormTemplate } from "@lib/formsClient/types/formTemplate.js";
+import { auditLog } from "@lib/logging/auditLogs.js";
 import {
   RequestContextualStoreKey,
   retrieveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import type { ApiOperation } from "@operations/types/operation.js";
+import type { NextFunction, Request, Response } from "express";
 
 async function v1(
   request: Request,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,22 +1,22 @@
-import { Router } from "express";
-import { routeNotFoundMiddleware } from "@middleware/routeNotFound.js";
-import { globalErrorHandlerMiddleware } from "@middleware/globalErrorHandler.js";
 import { authenticationMiddleware } from "@middleware/authentication.js";
+import { extractClientIpMiddleware } from "@middleware/extractClientIp.js";
+import { globalErrorHandlerMiddleware } from "@middleware/globalErrorHandler.js";
 import { rateLimiterMiddleware } from "@middleware/rateLimiter.js";
+import { requestContextMiddleware } from "@middleware/requestContext.js";
+import { routeNotFoundMiddleware } from "@middleware/routeNotFound.js";
+import { versionMiddleware } from "@middleware/version.js";
 import { checkServiceHealthOperation } from "@operations/checkServiceHealth.js";
-import { retrieveTemplateOperationV1 } from "@operations/retrieveTemplate.v1.js";
-import { retrieveNewSubmissionsOperationV1 } from "@operations/retrieveNewSubmissions.v1.js";
-import { retrieveSubmissionOperationV1 } from "@operations/retrieveSubmission.v1.js";
 import { confirmSubmissionOperationV1 } from "@operations/confirmSubmission.v1.js";
 import { reportSubmissionOperationV1 } from "@operations/reportSubmission.v1.js";
-import { versionMiddleware } from "@middleware/version.js";
-import { requestContextMiddleware } from "@middleware/requestContext.js";
-import cors from "cors";
+import { retrieveNewSubmissionsOperationV1 } from "@operations/retrieveNewSubmissions.v1.js";
+import { retrieveSubmissionOperationV1 } from "@operations/retrieveSubmission.v1.js";
+import { retrieveTemplateOperationV1 } from "@operations/retrieveTemplate.v1.js";
 import type {
   ApiOperation,
   OperationHandler,
 } from "@operations/types/operation.js";
-import { extractClientIpMiddleware } from "@middleware/extractClientIp.js";
+import cors from "cors";
+import { Router } from "express";
 
 // Router configuration to inherit from parent router params
 const INHERIT_PARAMS = { mergeParams: true };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,11 @@
 import "dotenv/config";
-import express, { type Express } from "express";
 import { SERVER_PORT } from "@config";
-import { buildRouter } from "./router.js";
+import { prisma } from "@gcforms/database";
 import { getApiAuditLogSqsQueueUrl } from "@lib/integration/awsSqsQueueLoader.js";
 import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
 import { logMessage } from "@lib/logging/logger.js";
-import { prisma } from "@gcforms/database";
+import express, { type Express } from "express";
+import { buildRouter } from "./router.js";
 
 const server: Express = express();
 

--- a/test/lib/encryption/encryptResponse.test.ts
+++ b/test/lib/encryption/encryptResponse.test.ts
@@ -1,8 +1,8 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { encryptResponse } from "@lib/encryption/encryptResponse.js";
-import { logMessage } from "@lib/logging/logger.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as crypto from "node:crypto";
+import { encryptResponse } from "@lib/encryption/encryptResponse.js";
+import { logMessage } from "@lib/logging/logger.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("encryptFormSubmission should", () => {
   beforeEach(() => {

--- a/test/lib/formsClient/getFormTemplate.test.ts
+++ b/test/lib/formsClient/getFormTemplate.test.ts
@@ -1,7 +1,7 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { type PrismaClient, type Template, prisma } from "@gcforms/database";
 import { getFormTemplate } from "@lib/formsClient/getFormTemplate.js";
 import { logMessage } from "@lib/logging/logger.js";
-import { prisma, type Template, type PrismaClient } from "@gcforms/database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type DeepMockProxy, mockReset } from "vitest-mock-extended";
 
 const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;

--- a/test/lib/formsClient/getPublicKey.test.ts
+++ b/test/lib/formsClient/getPublicKey.test.ts
@@ -1,15 +1,15 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import {
+  type ApiServiceAccount,
+  type PrismaClient,
+  prisma,
+} from "@gcforms/database";
 import { getPublicKey } from "@lib/formsClient/getPublicKey.js";
 import {
   getValueFromRedis,
   setValueInRedis,
 } from "@lib/integration/redis/redisClientAdapter.js";
 import { logMessage } from "@lib/logging/logger.js";
-import {
-  type ApiServiceAccount,
-  prisma,
-  type PrismaClient,
-} from "@gcforms/database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type DeepMockProxy, mockReset } from "vitest-mock-extended";
 
 vi.mock("@lib/integration/redis/redisClientAdapter");

--- a/test/lib/idp/verifyAccessToken.test.ts
+++ b/test/lib/idp/verifyAccessToken.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
-  verifyAccessToken,
-  AccessTokenInvalidError,
-  AccessTokenExpiredError,
   AccessControlError,
+  AccessTokenExpiredError,
+  AccessTokenInvalidError,
   AccessTokenMalformedError,
+  verifyAccessToken,
 } from "@lib/idp/verifyAccessToken.js";
-import {
-  introspectAccessToken,
-  ZitadelConnectionError,
-} from "@lib/integration/zitadelConnector.js";
 import {
   getValueFromRedis,
   setValueInRedis,
 } from "@lib/integration/redis/redisClientAdapter.js";
-import { logMessage } from "@lib/logging/logger.js";
+import {
+  ZitadelConnectionError,
+  introspectAccessToken,
+} from "@lib/integration/zitadelConnector.js";
 import { auditLog } from "@lib/logging/auditLogs.js";
+import { logMessage } from "@lib/logging/logger.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lib/integration/redis/redisClientAdapter");
 const getValueFromRedisMock = vi.mocked(getValueFromRedis);

--- a/test/lib/integration/awsSqsQueueLoader.test.ts
+++ b/test/lib/integration/awsSqsQueueLoader.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mockClient } from "aws-sdk-client-mock";
 import { GetQueueUrlCommand, SQSClient } from "@aws-sdk/client-sqs";
 import { getApiAuditLogSqsQueueUrl } from "@lib/integration/awsSqsQueueLoader.js";
+import { mockClient } from "aws-sdk-client-mock";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sqsMock = mockClient(SQSClient);
 

--- a/test/lib/integration/freshdeskConnector.test.ts
+++ b/test/lib/integration/freshdeskConnector.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createFreshdeskTicket } from "@lib/integration/freshdeskConnector.js";
 import got from "got";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("createFreshdeskTicket should", () => {
   beforeEach(() => {

--- a/test/lib/integration/redis/redisClientAdapter.test.ts
+++ b/test/lib/integration/redis/redisClientAdapter.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
 import {
   getValueFromRedis,
   setValueInRedis,
 } from "@lib/integration/redis/redisClientAdapter.js";
+import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lib/integration/redis/redisConnector");
 const redisConnectorMock = vi.mocked(RedisConnector);

--- a/test/lib/integration/redis/redisConnector.test.ts
+++ b/test/lib/integration/redis/redisConnector.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as redisModule from "redis";
-import { RedisConnector } from "@lib/integration/redis/redisConnector.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const redisCreateClientSpy = vi.spyOn(redisModule, "createClient");
 

--- a/test/lib/integration/zitadelConnector.test.ts
+++ b/test/lib/integration/zitadelConnector.test.ts
@@ -1,11 +1,11 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { SignJWT } from "jose";
-import got from "got";
 import {
-  introspectAccessToken,
   ZitadelConnectionError,
+  introspectAccessToken,
 } from "@lib/integration/zitadelConnector.js";
 import { logMessage } from "@lib/logging/logger.js";
+import got from "got";
+import { SignJWT } from "jose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.spyOn(SignJWT.prototype, "sign").mockResolvedValue("signedJwtToken");
 

--- a/test/lib/logging/auditLogs.test.ts
+++ b/test/lib/logging/auditLogs.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
-import { mockClient } from "aws-sdk-client-mock";
-import { SendMessageCommand, SQSClient } from "@aws-sdk/client-sqs";
-import { auditLog } from "@lib/logging/auditLogs.js";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { getApiAuditLogSqsQueueUrl } from "@lib/integration/awsSqsQueueLoader.js";
+import { auditLog } from "@lib/logging/auditLogs.js";
 import { logMessage } from "@lib/logging/logger.js";
 import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { mockClient } from "aws-sdk-client-mock";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.unmock("@lib/logging/auditLogs");
 

--- a/test/lib/rateLimiting/tokenBucketLimiter.test.ts
+++ b/test/lib/rateLimiting/tokenBucketLimiter.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   consumeTokenIfAvailable,
   refundConsumedToken,
 } from "@lib/rateLimiting/tokenBucketLimiter.js";
 import { getTokenBucketRateLimiterAssociatedToForm } from "@lib/rateLimiting/tokenBucketProvider.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lib/rateLimiting/tokenBucketProvider");
 const getTokenBucketRateLimiterAssociatedToFormMock = vi.mocked(

--- a/test/lib/rateLimiting/tokenBucketProvider.test.ts
+++ b/test/lib/rateLimiting/tokenBucketProvider.test.ts
@@ -1,7 +1,7 @@
-import { vi, describe, it, expect } from "vitest";
-import { getTokenBucketRateLimiterAssociatedToForm } from "@lib/rateLimiting/tokenBucketProvider.js";
 import { getValueFromRedis } from "@lib/integration/redis/redisClientAdapter.js";
 import { logMessage } from "@lib/logging/logger.js";
+import { getTokenBucketRateLimiterAssociatedToForm } from "@lib/rateLimiting/tokenBucketProvider.js";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@lib/integration/redis/redisClientAdapter");
 const getValueFromRedisMock = vi.mocked(getValueFromRedis);

--- a/test/lib/storage/requestContextualStore.test.ts
+++ b/test/lib/storage/requestContextualStore.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from "vitest";
 import {
-  requestContextualStore,
   RequestContextualStoreKey,
+  requestContextualStore,
   retrieveOptionalRequestContextData,
   retrieveRequestContextData,
   saveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import { describe, expect, it } from "vitest";
 
 describe("requestContextualStore", () => {
   describe("saveRequestContextData should", () => {

--- a/test/lib/support/notifySupportAboutFormSubmissionProblem.test.ts
+++ b/test/lib/support/notifySupportAboutFormSubmissionProblem.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { notifySupportAboutFormSubmissionProblem } from "@lib/support/notifySupportAboutFormSubmissionProblem.js";
-import { createFreshdeskTicket } from "@lib/integration/freshdeskConnector.js";
 import { EnvironmentMode } from "@config";
+import { createFreshdeskTicket } from "@lib/integration/freshdeskConnector.js";
 import { logMessage } from "@lib/logging/logger.js";
+import { notifySupportAboutFormSubmissionProblem } from "@lib/support/notifySupportAboutFormSubmissionProblem.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lib/integration/freshdeskConnector");
 const createFreshdeskTicketMock = vi.mocked(createFreshdeskTicket);

--- a/test/lib/vault/confirmFormSubmission.test.ts
+++ b/test/lib/vault/confirmFormSubmission.test.ts
@@ -1,18 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mockClient } from "aws-sdk-client-mock";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
+import { logMessage } from "@lib/logging/logger.js";
 import { confirmFormSubmission } from "@lib/vault/confirmFormSubmission.js";
 import {
   FormSubmissionAlreadyConfirmedException,
   FormSubmissionIncorrectConfirmationCodeException,
   FormSubmissionNotFoundException,
 } from "@lib/vault/types/exceptions.types.js";
-import { logMessage } from "@lib/logging/logger.js";
+import { mockClient } from "aws-sdk-client-mock";
 import { buildMockedVaultItem } from "test/mocks/dynamodb.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const dynamoDbMock = mockClient(DynamoDBDocumentClient);
 

--- a/test/lib/vault/getFormSubmission.test.ts
+++ b/test/lib/vault/getFormSubmission.test.ts
@@ -1,11 +1,11 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { mockClient } from "aws-sdk-client-mock";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
-import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
-import { SubmissionStatus } from "@lib/vault/types/formSubmission.types.js";
 import { logMessage } from "@lib/logging/logger.js";
-import { buildMockedVaultItem } from "test/mocks/dynamodb.js";
+import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
 import { FormSubmissionNotFoundException } from "@lib/vault/types/exceptions.types.js";
+import { SubmissionStatus } from "@lib/vault/types/formSubmission.types.js";
+import { mockClient } from "aws-sdk-client-mock";
+import { buildMockedVaultItem } from "test/mocks/dynamodb.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const dynamoDbMock = mockClient(DynamoDBDocumentClient);
 

--- a/test/lib/vault/getFormSubmissionAttachmentDownloadLink.test.ts
+++ b/test/lib/vault/getFormSubmissionAttachmentDownloadLink.test.ts
@@ -1,7 +1,7 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { logMessage } from "@lib/logging/logger.js";
 import { getFormSubmissionAttachmentDownloadLink } from "@lib/vault/getFormSubmissionAttachmentDownloadLink.js";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@aws-sdk/s3-request-presigner");
 const getSignedUrlMock = vi.mocked(getSignedUrl);

--- a/test/lib/vault/getNewFormSubmissions.test.ts
+++ b/test/lib/vault/getNewFormSubmissions.test.ts
@@ -1,8 +1,8 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { mockClient } from "aws-sdk-client-mock";
 import { DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/lib-dynamodb";
-import { getNewFormSubmissions } from "@lib/vault/getNewFormSubmissions.js";
 import { logMessage } from "@lib/logging/logger.js";
+import { getNewFormSubmissions } from "@lib/vault/getNewFormSubmissions.js";
+import { mockClient } from "aws-sdk-client-mock";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const dynamoDbMock = mockClient(DynamoDBDocumentClient);
 

--- a/test/lib/vault/mappers/formSubmission.mapper.test.ts
+++ b/test/lib/vault/mappers/formSubmission.mapper.test.ts
@@ -3,7 +3,7 @@ import {
   mapNewFormSubmissionFromDynamoDbResponse,
 } from "@lib/vault/mappers/formSubmission.mapper.js";
 import { AttachmentScanStatus } from "@lib/vault/types/formSubmission.types.js";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("in formSubmission mapper", () => {
   describe("mapNewFormSubmissionFromDynamoDbResponse should", () => {

--- a/test/lib/vault/reportProblemWithFormSubmission.test.ts
+++ b/test/lib/vault/reportProblemWithFormSubmission.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { mockClient } from "aws-sdk-client-mock";
 import {
   DynamoDBDocumentClient,
   GetCommand,
   UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
+import { logMessage } from "@lib/logging/logger.js";
 import { reportProblemWithFormSubmission } from "@lib/vault/reportProblemWithFormSubmission.js";
 import {
   FormSubmissionAlreadyReportedAsProblematicException,
   FormSubmissionNotFoundException,
 } from "@lib/vault/types/exceptions.types.js";
-import { logMessage } from "@lib/logging/logger.js";
+import { mockClient } from "aws-sdk-client-mock";
 import { buildMockedVaultItem } from "test/mocks/dynamodb.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const dynamoDbMock = mockClient(DynamoDBDocumentClient);
 

--- a/test/middleware/authentication.test.ts
+++ b/test/middleware/authentication.test.ts
@@ -1,16 +1,16 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
 import {
+  AccessControlError,
+  AccessTokenExpiredError,
+  AccessTokenInvalidError,
   type VerifiedAccessToken,
   verifyAccessToken,
-  AccessTokenInvalidError,
-  AccessTokenExpiredError,
-  AccessControlError,
 } from "@lib/idp/verifyAccessToken.js";
-import { authenticationMiddleware } from "@middleware/authentication.js";
 import { RequestContextualStoreKey } from "@lib/storage/requestContextualStore.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as requestContextualStoreModule from "@lib/storage/requestContextualStore.js";
+import { authenticationMiddleware } from "@middleware/authentication.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/idp/verifyAccessToken");
 const verifyAccessTokenMock = vi.mocked(verifyAccessToken);

--- a/test/middleware/extractClientIp.test.ts
+++ b/test/middleware/extractClientIp.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
-import { extractClientIpMiddleware } from "@middleware/extractClientIp.js";
 import {
   RequestContextualStoreKey,
   saveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import { extractClientIpMiddleware } from "@middleware/extractClientIp.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/storage/requestContextualStore");
 const saveRequestContextDataMock = vi.mocked(saveRequestContextData);

--- a/test/middleware/globalErrorHandler.test.ts
+++ b/test/middleware/globalErrorHandler.test.ts
@@ -1,11 +1,11 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
-import type { Request } from "express";
-import { globalErrorHandlerMiddleware } from "@middleware/globalErrorHandler.js";
 import { logMessage } from "@lib/logging/logger.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as tokenBucketLimiterModule from "@lib/rateLimiting/tokenBucketLimiter.js";
 import { retrieveOptionalRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { globalErrorHandlerMiddleware } from "@middleware/globalErrorHandler.js";
+import type { Request } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/storage/requestContextualStore");
 const retrieveOptionalRequestContextDataMock = vi.mocked(

--- a/test/middleware/rateLimiter.test.ts
+++ b/test/middleware/rateLimiter.test.ts
@@ -1,11 +1,11 @@
-import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
-import { rateLimiterMiddleware } from "@middleware/rateLimiter.js";
-import { consumeTokenIfAvailable } from "@lib/rateLimiting/tokenBucketLimiter.js";
 import { logMessage } from "@lib/logging/logger.js";
+import { consumeTokenIfAvailable } from "@lib/rateLimiting/tokenBucketLimiter.js";
 import { RequestContextualStoreKey } from "@lib/storage/requestContextualStore.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as requestContextualStoreModule from "@lib/storage/requestContextualStore.js";
+import { rateLimiterMiddleware } from "@middleware/rateLimiter.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/rateLimiting/tokenBucketLimiter");
 const consumeTokenIfAvailableMock = vi.mocked(consumeTokenIfAvailable);

--- a/test/middleware/requestContext.test.ts
+++ b/test/middleware/requestContext.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
-import { requestContextMiddleware } from "@middleware/requestContext.js";
 import { AsyncLocalStorage } from "node:async_hooks";
+import { requestContextMiddleware } from "@middleware/requestContext.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 describe("requestContextMiddleware should", () => {
   const requestMock = getMockReq();

--- a/test/middleware/requestValidator.test.ts
+++ b/test/middleware/requestValidator.test.ts
@@ -1,15 +1,15 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
+import { requestValidatorMiddleware } from "@middleware/requestValidator.js";
 import {
-  checkSchema,
+  type Result,
   type Schema,
-  validationResult,
   type ValidationChain,
   type ValidationError,
-  type Result,
+  checkSchema,
+  validationResult,
 } from "express-validator";
 import type { RunnableValidationChains } from "express-validator/lib/middlewares/schema.js";
-import { requestValidatorMiddleware } from "@middleware/requestValidator.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("express-validator");
 const checkSchemaMock = vi.mocked(checkSchema);

--- a/test/middleware/routeNotFound.test.ts
+++ b/test/middleware/routeNotFound.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
 import { routeNotFoundMiddleware } from "@middleware/routeNotFound.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 describe("routeNotFoundMiddleware should", () => {
   const requestMock = getMockReq();

--- a/test/middleware/version.test.ts
+++ b/test/middleware/version.test.ts
@@ -1,6 +1,6 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
 import { versionMiddleware } from "@middleware/version.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 describe("versionMiddleware should", () => {
   const { res: responseMock, next: nextMock, clearMockRes } = getMockRes();

--- a/test/operations/checkServiceHealth.test.ts
+++ b/test/operations/checkServiceHealth.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
 import { checkServiceHealthOperation } from "@operations/checkServiceHealth.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 describe("checkServiceHealthOperation handler should", () => {
   const { res: responseMock, next: nextMock, clearMockRes } = getMockRes();

--- a/test/operations/confirmSubmission.v1.test.ts
+++ b/test/operations/confirmSubmission.v1.test.ts
@@ -1,15 +1,15 @@
-import { vi, describe, beforeEach, it, expect } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
-import { confirmFormSubmission } from "@lib/vault/confirmFormSubmission.js";
-import {
-  FormSubmissionAlreadyConfirmedException,
-  FormSubmissionNotFoundException,
-  FormSubmissionIncorrectConfirmationCodeException,
-} from "@lib/vault/types/exceptions.types.js";
-import { confirmSubmissionOperationV1 } from "@operations/confirmSubmission.v1.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as auditLogsModule from "@lib/logging/auditLogs.js";
 import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { confirmFormSubmission } from "@lib/vault/confirmFormSubmission.js";
+import {
+  FormSubmissionAlreadyConfirmedException,
+  FormSubmissionIncorrectConfirmationCodeException,
+  FormSubmissionNotFoundException,
+} from "@lib/vault/types/exceptions.types.js";
+import { confirmSubmissionOperationV1 } from "@operations/confirmSubmission.v1.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/vault/confirmFormSubmission");
 const confirmFormSubmissionMock = vi.mocked(confirmFormSubmission);

--- a/test/operations/reportSubmission.v1.test.ts
+++ b/test/operations/reportSubmission.v1.test.ts
@@ -1,15 +1,15 @@
-import { vi, describe, beforeEach, it, expect } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
+// biome-ignore lint/style/noNamespaceImport: <explanation>
+import * as auditLogsModule from "@lib/logging/auditLogs.js";
+import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { notifySupportAboutFormSubmissionProblem } from "@lib/support/notifySupportAboutFormSubmissionProblem.js";
 import { reportProblemWithFormSubmission } from "@lib/vault/reportProblemWithFormSubmission.js";
 import {
   FormSubmissionAlreadyReportedAsProblematicException,
   FormSubmissionNotFoundException,
 } from "@lib/vault/types/exceptions.types.js";
-import { notifySupportAboutFormSubmissionProblem } from "@lib/support/notifySupportAboutFormSubmissionProblem.js";
 import { reportSubmissionOperationV1 } from "@operations/reportSubmission.v1.js";
-// biome-ignore lint/style/noNamespaceImport: <explanation>
-import * as auditLogsModule from "@lib/logging/auditLogs.js";
-import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/vault/reportProblemWithFormSubmission");
 const reportProblemWithFormSubmissionMock = vi.mocked(

--- a/test/operations/retrieveNewSubmissions.v1.test.ts
+++ b/test/operations/retrieveNewSubmissions.v1.test.ts
@@ -1,10 +1,10 @@
-import { vi, describe, beforeEach, it, expect } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
-import { getNewFormSubmissions } from "@lib/vault/getNewFormSubmissions.js";
-import { retrieveNewSubmissionsOperationV1 } from "@operations/retrieveNewSubmissions.v1.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as auditLogsModule from "@lib/logging/auditLogs.js";
 import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { getNewFormSubmissions } from "@lib/vault/getNewFormSubmissions.js";
+import { retrieveNewSubmissionsOperationV1 } from "@operations/retrieveNewSubmissions.v1.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/vault/getNewFormSubmissions");
 const getNewFormSubmissionsMock = vi.mocked(getNewFormSubmissions);

--- a/test/operations/retrieveSubmission.v1.test.ts
+++ b/test/operations/retrieveSubmission.v1.test.ts
@@ -1,18 +1,18 @@
-import { vi, describe, beforeEach, it, expect } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
-import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
 import { encryptResponse } from "@lib/encryption/encryptResponse.js";
-import { retrieveSubmissionOperationV1 } from "@operations/retrieveSubmission.v1.js";
+import { getPublicKey } from "@lib/formsClient/getPublicKey.js";
+// biome-ignore lint/style/noNamespaceImport: <explanation>
+import * as auditLogsModule from "@lib/logging/auditLogs.js";
+import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { getFormSubmission } from "@lib/vault/getFormSubmission.js";
+import { getFormSubmissionAttachmentDownloadLink } from "@lib/vault/getFormSubmissionAttachmentDownloadLink.js";
+import { FormSubmissionNotFoundException } from "@lib/vault/types/exceptions.types.js";
 import {
   AttachmentScanStatus,
   SubmissionStatus,
 } from "@lib/vault/types/formSubmission.types.js";
-// biome-ignore lint/style/noNamespaceImport: <explanation>
-import * as auditLogsModule from "@lib/logging/auditLogs.js";
-import { FormSubmissionNotFoundException } from "@lib/vault/types/exceptions.types.js";
-import { getPublicKey } from "@lib/formsClient/getPublicKey.js";
-import { getFormSubmissionAttachmentDownloadLink } from "@lib/vault/getFormSubmissionAttachmentDownloadLink.js";
-import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { retrieveSubmissionOperationV1 } from "@operations/retrieveSubmission.v1.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/formsClient/getPublicKey");
 const getPublicKeyMock = vi.mocked(getPublicKey);

--- a/test/operations/retrieveTemplate.v1.test.ts
+++ b/test/operations/retrieveTemplate.v1.test.ts
@@ -1,10 +1,10 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
-import { getMockReq, getMockRes } from "vitest-mock-express";
 import { getFormTemplate } from "@lib/formsClient/getFormTemplate.js";
-import { retrieveTemplateOperationV1 } from "@operations/retrieveTemplate.v1.js";
 // biome-ignore lint/style/noNamespaceImport: <explanation>
 import * as auditLogsModule from "@lib/logging/auditLogs.js";
 import { retrieveRequestContextData } from "@lib/storage/requestContextualStore.js";
+import { retrieveTemplateOperationV1 } from "@operations/retrieveTemplate.v1.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("@lib/formsClient/getFormTemplate");
 const getFormTemplateMock = vi.mocked(getFormTemplate);

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,13 +1,13 @@
-import { vi, describe, it, expect, beforeEach, beforeAll } from "vitest";
-import request from "supertest";
+import { authenticationMiddleware } from "@middleware/authentication.js";
+import type { ApiOperation } from "@operations/types/operation.js";
 import express, {
   type Response,
   type Request,
   type NextFunction,
 } from "express";
+import request from "supertest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildRouter } from "../src/router.js";
-import type { ApiOperation } from "@operations/types/operation.js";
-import { authenticationMiddleware } from "@middleware/authentication.js";
 
 vi.mock("@middleware/rateLimiter", () => ({
   rateLimiterMiddleware: (_: Request, __: Response, next: NextFunction) =>

--- a/vitest-setup.ts
+++ b/vitest-setup.ts
@@ -1,6 +1,6 @@
+import type { PrismaClient } from "@gcforms/database";
 import { vi } from "vitest";
 import { mockDeep } from "vitest-mock-extended";
-import type { PrismaClient } from "@gcforms/database";
 
 process.env = {
   ...process.env,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
 
 // biome-ignore lint/style/noDefaultExport: <explanation>
 export default defineConfig({


### PR DESCRIPTION
# Summary | Résumé

- Upgrades PNPM to version 11.8.0
- Simplifies CI test workflow with a single check command that runs both formatter and linter sub commands
- Upgrades Github checkout action to version 7.0.0 (starting to upgrade some sub dependencies due to deprecation of Node20 in Github Actions https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners)
- Resolves lint issues by letting Biome reorganize imports when we save a file