### PR TITLE
chore: improve input validation method for get template operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
-    "express-validator": "^7.2.0",
+    "express-validator": "^7.3.2",
     "got": "^14.4.7",
     "jose": "^5.9.3",
     "pino": "^9.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^4.21.0
         version: 4.22.2
       express-validator:
-        specifier: ^7.2.0
+        specifier: ^7.3.2
         version: 7.3.2
       got:
         specifier: ^14.4.7

--- a/src/middleware/requestValidator.ts
+++ b/src/middleware/requestValidator.ts
@@ -1,10 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
-import {
-  type Location,
-  type Schema,
-  checkSchema,
-  validationResult,
-} from "express-validator";
+import { type Location, type Schema, checkSchema } from "express-validator";
 
 export function requestValidatorMiddleware(
   validationSchema: Schema,
@@ -16,18 +11,25 @@ export function requestValidatorMiddleware(
     next: NextFunction,
   ): Promise<void> => {
     try {
-      /**
-       * Because of an existing issue we have to run the next two lines of code instead of just the first one.
-       * See https://github.com/express-validator/express-validator/issues/1298
-       */
-      await checkSchema(validationSchema, validationLocations).run(request);
+      const schemaValidationResults = await checkSchema(
+        validationSchema,
+        validationLocations,
+      ).run(request);
 
-      const result = validationResult(request);
+      const isPayloadInvalid = schemaValidationResults.some(
+        (result) => result.isEmpty() === false,
+      );
 
-      if (result.isEmpty() === false) {
-        response
-          .status(400)
-          .json({ error: "Invalid payload", details: result.array() });
+      const detectedErrors = schemaValidationResults.flatMap((result) =>
+        result.array(),
+      );
+
+      if (isPayloadInvalid) {
+        response.status(400).json({
+          error: "Invalid payload",
+          details: detectedErrors,
+        });
+
         return;
       }
 

--- a/src/operations/reportSubmission.v1.ts
+++ b/src/operations/reportSubmission.v1.ts
@@ -23,11 +23,11 @@ import type { Schema } from "express-validator";
 const validationSchema: Schema = {
   contactEmail: {
     exists: { bail: true, errorMessage: "Missing contactEmail property" },
-    isEmail: true,
+    isEmail: { errorMessage: "Must be a valid email address" },
   },
   description: {
     exists: { bail: true, errorMessage: "Missing description property" },
-    isString: true,
+    isString: { errorMessage: "Must be a string" },
     isLength: {
       options: { min: 10, max: 1000 },
       errorMessage: "Text length must be between 10 and 1000 characters",

--- a/src/operations/retrieveTemplate.v1.ts
+++ b/src/operations/retrieveTemplate.v1.ts
@@ -5,8 +5,17 @@ import {
   RequestContextualStoreKey,
   retrieveRequestContextData,
 } from "@lib/storage/requestContextualStore.js";
+import { requestValidatorMiddleware } from "@middleware/requestValidator.js";
 import type { ApiOperation } from "@operations/types/operation.js";
 import type { NextFunction, Request, Response } from "express";
+import type { Schema } from "express-validator";
+
+const validationSchema: Schema = {
+  version: {
+    optional: true,
+    isNumeric: { errorMessage: "Must be a number" },
+  },
+};
 
 async function v1(
   request: Request,
@@ -20,13 +29,6 @@ async function v1(
   const version = Number(request.query.version ?? 1);
 
   try {
-    if (Number.isNaN(version)) {
-      response
-        .status(400)
-        .json({ error: "URL parameter 'version' should be a number" });
-      return;
-    }
-
     const formTemplate = await getFormTemplate(formId, version);
 
     if (formTemplate === undefined) {
@@ -58,6 +60,6 @@ function buildResponse(formTemplate: FormTemplate): Record<string, unknown> {
 }
 
 export const retrieveTemplateOperationV1: ApiOperation = {
-  middleware: [],
+  middleware: [requestValidatorMiddleware(validationSchema, ["query"])],
   handler: v1,
 };

--- a/test/middleware/requestValidator.test.ts
+++ b/test/middleware/requestValidator.test.ts
@@ -1,11 +1,8 @@
 import { requestValidatorMiddleware } from "@middleware/requestValidator.js";
 import {
-  type Result,
   type Schema,
   type ValidationChain,
-  type ValidationError,
   checkSchema,
-  validationResult,
 } from "express-validator";
 import type { RunnableValidationChains } from "express-validator/lib/middlewares/schema.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,11 +10,6 @@ import { getMockReq, getMockRes } from "vitest-mock-express";
 
 vi.mock("express-validator");
 const checkSchemaMock = vi.mocked(checkSchema);
-const validationResultMock = vi.mocked(validationResult);
-
-checkSchemaMock.mockReturnValue({
-  run: vi.fn(),
-} as unknown as RunnableValidationChains<ValidationChain>);
 
 describe("requestValidatorMiddleware should", () => {
   const requestMock = getMockReq();
@@ -29,9 +21,14 @@ describe("requestValidatorMiddleware should", () => {
   });
 
   it("pass to the next function when validation is successful", async () => {
-    validationResultMock.mockReturnValueOnce({
-      isEmpty: vi.fn().mockReturnValue(true),
-    } as Partial<Result<ValidationError>> as Result<ValidationError>);
+    checkSchemaMock.mockReturnValueOnce({
+      run: vi.fn().mockResolvedValueOnce([
+        {
+          isEmpty: vi.fn().mockReturnValue(true),
+          array: vi.fn().mockReturnValue([]),
+        },
+      ]),
+    } as unknown as RunnableValidationChains<ValidationChain>);
 
     await requestValidatorMiddleware({} as Schema)(
       requestMock,
@@ -43,18 +40,22 @@ describe("requestValidatorMiddleware should", () => {
   });
 
   it("respond with error when validation failed because errors were detected", async () => {
-    validationResultMock.mockReturnValueOnce({
-      isEmpty: vi.fn().mockReturnValue(false),
-      array: vi.fn().mockReturnValue([
+    checkSchemaMock.mockReturnValueOnce({
+      run: vi.fn().mockResolvedValueOnce([
         {
-          type: "test",
-          value: "test",
-          msg: "test",
-          path: "test",
-          location: "test",
+          isEmpty: vi.fn().mockReturnValue(false),
+          array: vi.fn().mockReturnValue([
+            {
+              type: "test",
+              value: "test",
+              msg: "test",
+              path: "test",
+              location: "test",
+            },
+          ]),
         },
       ]),
-    } as Partial<Result<ValidationError>> as Result<ValidationError>);
+    } as unknown as RunnableValidationChains<ValidationChain>);
 
     await requestValidatorMiddleware({} as Schema)(
       requestMock,
@@ -79,9 +80,9 @@ describe("requestValidatorMiddleware should", () => {
   });
 
   it("pass error to next function when processing fails due to internal error", async () => {
-    validationResultMock.mockReturnValueOnce({
-      array: vi.fn().mockReturnValue(new Error("custom error")),
-    } as Partial<Result<ValidationError>> as Result<ValidationError>);
+    checkSchemaMock.mockReturnValueOnce({
+      run: vi.fn().mockRejectedValueOnce(new Error("custom error")),
+    } as unknown as RunnableValidationChains<ValidationChain>);
 
     await requestValidatorMiddleware({} as Schema)(
       requestMock,

--- a/test/operations/retrieveTemplate.v1.test.ts
+++ b/test/operations/retrieveTemplate.v1.test.ts
@@ -118,21 +118,23 @@ describe("retrieveTemplateOperation handler should", () => {
   });
 
   it("respond with error when 'version' query parameter is not a number", async () => {
-    getFormTemplateMock.mockRejectedValueOnce(new Error("custom error"));
     requestMock.query = {
       version: "hello",
     };
 
-    await retrieveTemplateOperationV1.handler(
-      requestMock,
-      responseMock,
-      nextMock,
-    );
+    for (const middleware of retrieveTemplateOperationV1.middleware) {
+      await middleware(requestMock, responseMock, nextMock);
+    }
 
     expect(responseMock.status).toHaveBeenCalledWith(400);
-    expect(responseMock.json).toHaveBeenCalledWith({
-      error: "URL parameter 'version' should be a number",
-    });
+    expect(responseMock.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: "Invalid payload",
+        details: expect.arrayContaining([
+          expect.objectContaining({ msg: "Must be a number" }),
+        ]),
+      }),
+    );
   });
 
   it("pass error to next function when processing fails due to internal error", async () => {


### PR DESCRIPTION
# Summary | Résumé

- Improves input validation method for get template operation (just trying to align with existing input validation method that was implemented for the "report problem with submission" endpoint)
- Upgrades `express-validator` package to version `7.3.2`
- Reworks usage of `express-validator` package now that a solution was found (see deleted comment)
- Adds a few new error messages to help make users understand why inputs are invalid