### PR TITLE
feat: return latest template if no version was requested

### DIFF
--- a/src/lib/formsClient/getFormTemplate.ts
+++ b/src/lib/formsClient/getFormTemplate.ts
@@ -2,50 +2,71 @@ import { prisma } from "@gcforms/database";
 import type { FormTemplate } from "@lib/formsClient/types/formTemplate.js";
 import { logMessage } from "@lib/logging/logger.js";
 
-export async function getFormTemplate(
+export function getFormTemplate(
+  formId: string,
+  version?: number,
+): Promise<FormTemplate | null> {
+  return (
+    version !== undefined
+      ? getVersionedTemplate(formId, version)
+      : getLatestTemplate(formId)
+  ).catch((error) => {
+    logMessage.error(
+      error,
+      `[formsClient] Failed to retrieve form template. FormId: ${formId}${version ? ` (with version: ${version})` : ""}`,
+    );
+
+    throw error;
+  });
+}
+
+function getVersionedTemplate(
   formId: string,
   version: number,
-): Promise<FormTemplate | undefined> {
-  try {
-    const template = await prisma.templateVersion
-      .findUnique({
-        where: {
-          templateId_versionNumber: {
-            templateId: formId,
-            versionNumber: version,
-          },
+): Promise<FormTemplate | null> {
+  return prisma.templateVersion
+    .findUnique({
+      where: {
+        templateId_versionNumber: {
+          templateId: formId,
+          versionNumber: version,
         },
-        select: {
-          jsonConfig: true,
-        },
-      })
-      // Fallback query to be deleted once form versioning is fully released in Production
-      .then((result) => {
-        if (result !== null) {
-          return result;
-        }
+      },
+      select: {
+        jsonConfig: true,
+      },
+    })
+    .then((result) => (result ? (result as FormTemplate) : null));
+}
 
-        return prisma.template.findUnique({
+function getLatestTemplate(formId: string): Promise<FormTemplate | null> {
+  return prisma.templateVersion
+    .findFirst({
+      where: {
+        templateId: formId,
+      },
+      orderBy: {
+        versionNumber: "desc",
+      },
+      select: {
+        jsonConfig: true,
+      },
+    })
+    .then((template) => {
+      if (template !== null) {
+        return template as FormTemplate;
+      }
+
+      // Fallback query to be deleted once form versioning is fully released in Production
+      return prisma.template
+        .findUnique({
           where: {
             id: formId,
           },
           select: {
             jsonConfig: true,
           },
-        });
-      });
-
-    if (template === null) {
-      return undefined;
-    }
-
-    return template as FormTemplate;
-  } catch (error) {
-    logMessage.error(
-      error,
-      `[formsClient] Failed to retrieve form template. FormId: ${formId}`,
-    );
-
-    throw error;
-  }
+        })
+        .then((result) => (result ? (result as FormTemplate) : null));
+    });
 }

--- a/src/operations/retrieveTemplate.v1.ts
+++ b/src/operations/retrieveTemplate.v1.ts
@@ -26,12 +26,15 @@ async function v1(
   const serviceUserId = retrieveRequestContextData(
     RequestContextualStoreKey.serviceUserId,
   );
-  const version = Number(request.query.version ?? 1);
+  const version =
+    request.query.version !== undefined
+      ? Number(request.query.version)
+      : undefined;
 
   try {
     const formTemplate = await getFormTemplate(formId, version);
 
-    if (formTemplate === undefined) {
+    if (formTemplate === null) {
       response.status(404).json({ error: "Form template does not exist" });
       return;
     }

--- a/test/lib/formsClient/getFormTemplate.test.ts
+++ b/test/lib/formsClient/getFormTemplate.test.ts
@@ -11,89 +11,158 @@ import { type DeepMockProxy, mockReset } from "vitest-mock-extended";
 
 const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;
 
-describe("getFormTemplate should", () => {
+describe("getFormTemplate", () => {
   beforeEach(() => {
     mockReset(prismaMock);
     vi.clearAllMocks();
   });
 
-  it("return an undefined form template if database was not able to find it", async () => {
-    prismaMock.templateVersion.findUnique.mockResolvedValueOnce(null);
+  describe("with no provided version should", () => {
+    it("return null if database was not able to find form template", async () => {
+      prismaMock.templateVersion.findFirst.mockResolvedValueOnce(null);
+      prismaMock.template.findUnique.mockResolvedValueOnce(null); // Should be deleted once "Fallback query to be deleted once form versioning is fully released in Production" comment and associated code is removed
 
-    const formTemplate = await getFormTemplate("clzamy5qv0000115huc4bh90m", 1);
+      const formTemplate = await getFormTemplate("clzamy5qv0000115huc4bh90m");
 
-    expect(formTemplate).toBeUndefined();
-  });
-
-  it("return a form template if database was able to find it", async () => {
-    prismaMock.templateVersion.findUnique.mockResolvedValue({
-      jsonConfig: {
-        elements: [
-          {
-            id: 1,
-            type: "textField",
-          },
-        ],
-      },
-    } as unknown as TemplateVersion);
-
-    const formTemplate = await getFormTemplate("clzamy5qv0000115huc4bh90m", 1);
-
-    expect(formTemplate).toEqual({
-      jsonConfig: {
-        elements: [
-          {
-            id: 1,
-            type: "textField",
-          },
-        ],
-      },
+      expect(formTemplate).toBeNull();
     });
-  });
 
-  // This test can be deleted once form versioning is implemented in Production and migrated old form template database entries to the new versioned schema
-  it("return a form template even if form versioning is not fully deployed (testing fallback Prisma query)", async () => {
-    prismaMock.templateVersion.findUnique.mockResolvedValue(null);
+    it("return form template if found in database", async () => {
+      prismaMock.templateVersion.findFirst.mockResolvedValue({
+        jsonConfig: {
+          elements: [
+            {
+              id: 1,
+              type: "textField",
+            },
+          ],
+        },
+      } as unknown as TemplateVersion);
 
-    prismaMock.template.findUnique.mockResolvedValue({
-      jsonConfig: {
-        elements: [
-          {
-            id: 1,
-            type: "textField",
-          },
-        ],
-      },
-    } as unknown as Template);
+      const formTemplate = await getFormTemplate("clzamy5qv0000115huc4bh90m");
 
-    const formTemplate = await getFormTemplate("clzamy5qv0000115huc4bh90m", 1);
-
-    expect(formTemplate).toEqual({
-      jsonConfig: {
-        elements: [
-          {
-            id: 1,
-            type: "textField",
-          },
-        ],
-      },
+      expect(prismaMock.templateVersion.findFirst).toHaveBeenCalledWith({
+        where: {
+          templateId: "clzamy5qv0000115huc4bh90m",
+        },
+        orderBy: {
+          versionNumber: "desc",
+        },
+        select: {
+          jsonConfig: true,
+        },
+      });
+      expect(formTemplate).toEqual({
+        jsonConfig: {
+          elements: [
+            {
+              id: 1,
+              type: "textField",
+            },
+          ],
+        },
+      });
     });
-  });
 
-  it("throw an error if database has an internal failure", async () => {
-    const customError = new Error("custom error");
-    prismaMock.templateVersion.findUnique.mockRejectedValueOnce(customError);
-    const logMessageSpy = vi.spyOn(logMessage, "error");
+    // This test can be deleted once form versioning is implemented in Production and migrated old form template database entries to the new versioned schema
+    it("return form template even if form versioning is not fully deployed (testing fallback Prisma query)", async () => {
+      prismaMock.templateVersion.findFirst.mockResolvedValue(null);
 
-    await expect(() =>
-      getFormTemplate("clzamy5qv0000115huc4bh90m", 1),
-    ).rejects.toThrow(customError);
+      prismaMock.template.findUnique.mockResolvedValue({
+        jsonConfig: {
+          elements: [
+            {
+              id: 1,
+              type: "textField",
+            },
+          ],
+        },
+      } as unknown as Template);
 
-    expect(logMessageSpy).toHaveBeenCalledWith(
-      customError,
-      expect.stringContaining(
+      const formTemplate = await getFormTemplate("clzamy5qv0000115huc4bh90m");
+
+      expect(formTemplate).toEqual({
+        jsonConfig: {
+          elements: [
+            {
+              id: 1,
+              type: "textField",
+            },
+          ],
+        },
+      });
+    });
+
+    it("throw an error if database has an internal failure", async () => {
+      const customError = new Error("custom error");
+      prismaMock.templateVersion.findFirst.mockRejectedValueOnce(customError);
+      const logMessageSpy = vi.spyOn(logMessage, "error");
+
+      await expect(() =>
+        getFormTemplate("clzamy5qv0000115huc4bh90m"),
+      ).rejects.toThrow(customError);
+
+      expect(logMessageSpy).toHaveBeenCalledWith(
+        customError,
         "[formsClient] Failed to retrieve form template. FormId: clzamy5qv0000115huc4bh90m",
-      ),
-    );
+      );
+    });
+  });
+
+  describe("with provided version should", () => {
+    it("return null if database was not able to find form template", async () => {
+      prismaMock.templateVersion.findUnique.mockResolvedValueOnce(null);
+
+      const formTemplate = await getFormTemplate(
+        "clzamy5qv0000115huc4bh90m",
+        1,
+      );
+
+      expect(formTemplate).toBeNull();
+    });
+
+    it("return form template if found in database", async () => {
+      prismaMock.templateVersion.findUnique.mockResolvedValue({
+        jsonConfig: {
+          elements: [
+            {
+              id: 1,
+              type: "textField",
+            },
+          ],
+        },
+      } as unknown as TemplateVersion);
+
+      const formTemplate = await getFormTemplate(
+        "clzamy5qv0000115huc4bh90m",
+        1,
+      );
+
+      expect(formTemplate).toEqual({
+        jsonConfig: {
+          elements: [
+            {
+              id: 1,
+              type: "textField",
+            },
+          ],
+        },
+      });
+    });
+
+    it("throw an error if database has an internal failure", async () => {
+      const customError = new Error("custom error");
+      prismaMock.templateVersion.findUnique.mockRejectedValueOnce(customError);
+      const logMessageSpy = vi.spyOn(logMessage, "error");
+
+      await expect(() =>
+        getFormTemplate("clzamy5qv0000115huc4bh90m", 1),
+      ).rejects.toThrow(customError);
+
+      expect(logMessageSpy).toHaveBeenCalledWith(
+        customError,
+        "[formsClient] Failed to retrieve form template. FormId: clzamy5qv0000115huc4bh90m (with version: 1)",
+      );
+    });
   });
 });

--- a/test/operations/retrieveTemplate.v1.test.ts
+++ b/test/operations/retrieveTemplate.v1.test.ts
@@ -103,7 +103,7 @@ describe("retrieveTemplateOperation handler should", () => {
   });
 
   it("respond with error when form template does not exist", async () => {
-    getFormTemplateMock.mockResolvedValueOnce(undefined);
+    getFormTemplateMock.mockResolvedValueOnce(null);
 
     await retrieveTemplateOperationV1.handler(
       requestMock,


### PR DESCRIPTION
# Summary | Résumé

- To match documentation that indicates that the latest template is returned by default

# Tests

- Make sure you are running an App build that has form versioning. Also make sure you enable the feature flag.
- Create a form, include v1 in the form name (to help identify which version of the template is returned by the API), enable API access and publish it
- Request template via the API:
  - `http://localhost:3001/forms/<form_id>/template` should return template template v1
  - `http://localhost:3001/forms/<form_id>/template?version=1` should return template template v1
  - `http://localhost:3001/forms/<form_id>/template?version=2` should return "Form not found"
- Edit previously published form, include v2 in the form name and keep it in draft
- Request template via the API:
  - `http://localhost:3001/forms/<form_id>/template` should return template template v2
  - `http://localhost:3001/forms/<form_id>/template?version=1` should return template template v1
  - `http://localhost:3001/forms/<form_id>/template?version=2` should return template template v2
  - `http://localhost:3001/forms/<form_id>/template?version=3` should return "Form not found"